### PR TITLE
datetime inside dict

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -75,7 +75,9 @@ class Unpickler(object):
             return self._pop(typeref)
 
         if has_tag(obj, tags.REPR):
-            return self._pop(loadrepr(obj[tags.REPR]))
+            obj = loadrepr(obj[tags.REPR])
+            self._mkref(obj)
+            return self._pop(obj)
 
         if has_tag(obj, tags.OBJECT):
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -319,6 +319,14 @@ class PicklingTestCase(unittest.TestCase):
         inflated = self.unpickler.restore(flattened)
         self.assertEqual(obj, inflated)
 
+    def test_datetime_inside_int_keys(self):
+        t = datetime.time(hour=10)
+        s = jsonpickle.encode({1:t, 2:t})
+        d = jsonpickle.decode(s)
+        self.assertEqual(d["1"], d["2"])
+        self.assertTrue(d["1"] is d["2"])
+        self.assertTrue(isinstance(d["1"], datetime.time))
+
     def test_broken_repr_dict_key(self):
         """Tests that we can pickle dictionaries with keys that have
         broken __repr__ implementations.


### PR DESCRIPTION
Register "repr" objects with the referencing machinery so that dicts that reference other objects are properly unpickled.
