### PR TITLE
Prefer nosetests for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - pip install -r requirements.txt
   - pip install -r requirements-test.txt
 script:
-  - nosetests
+  - nosetests --with-doctest


### PR DESCRIPTION
My understanding is nose is the best way to run the tests -- jsonpickle should use that when running the tests in continuous integration.
