### PR TITLE
Add a backward-compatibility shim to lessen the burden upgrading from 0.4

### DIFF
--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -54,4 +54,4 @@ class BaseHandler(object):
 class registry:
     @staticmethod
     def register(handled_type, handler_class):
-        pass
+        BaseHandler._registry[handled_type] = handler_class


### PR DESCRIPTION
In testing the latest code on jsonpickle, I realized that clients using 0.4 will find that the 'handlers.registry' object is no longer present, and clients that attempt to call it will fail. This patch provides backward compatibility to ease that transition for clients depending on that functionality.
