### PR TITLE
Add ability to use __getnewargs__ from protocol 2

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -200,6 +200,7 @@ class Pickler(object):
         has_class = hasattr(obj, '__class__')
         has_dict = hasattr(obj, '__dict__')
         has_slots = not has_dict and hasattr(obj, '__slots__')
+        has_getnewargs = hasattr(obj, '__getnewargs__')
 
         # Support objects with __getstate__(); this ensures that
         # both __setstate__() and __getstate__() are implemented
@@ -213,6 +214,9 @@ class Pickler(object):
             handler = handlers.get(obj.__class__)
             if handler is not None:
                 return handler(self).flatten(obj, data)
+
+            if has_getnewargs:
+                data[tags.NEWARGS] = obj.__getnewargs__()
 
         if util.is_module(obj):
             if self.unpicklable:

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -18,7 +18,8 @@ SET = 'py/set'
 SEQ = 'py/seq'
 STATE = 'py/state'
 FUNCTION = 'py/function'
+NEWARGS = 'py/newargs'
 JSON_KEY = 'json://'
 
 # All reserved tag names
-RESERVED = set([OBJECT, TYPE, REPR, REF, TUPLE, SET, SEQ, STATE, FUNCTION])
+RESERVED = set([OBJECT, TYPE, REPR, REF, TUPLE, SET, SEQ, STATE, FUNCTION, NEWARGS])

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -326,6 +326,11 @@ def loadclass(module_and_name):
 
 
 def getargs(obj):
+
+    # let saved newargs take precedence over everything
+    if has_tag(obj, tags.NEWARGS):
+        return obj[tags.NEWARGS]
+
     try:
         seq_list = obj[tags.SEQ]
         obj_dict = obj[tags.OBJECT]


### PR DESCRIPTION
As per this issue, jsonpickle right now doesn't use any of the protocol 2 magic methods: https://github.com/jsonpickle/jsonpickle/issues/78 

This adds the ability to use **getnewargs**.

If you're interested in supporting protocol 2, I can keep adding support for the other magic methods.
