### PR TITLE
Final, full protocol 2 support

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -224,9 +224,8 @@ class Pickler(object):
         has_dict = hasattr(obj, '__dict__')
         has_slots = not has_dict and hasattr(obj, '__slots__')
         has_getnewargs = hasattr(obj, '__getnewargs__')
+        has_getinitargs = hasattr(obj, '__getinitargs__')
         has_reduce, has_reduce_ex = util.has_reduce(obj)
-
-        # import pdb; pdb.set_trace()
 
         # Support objects with __getstate__(); this ensures that
         # both __setstate__() and __getstate__() are implemented
@@ -272,8 +271,9 @@ class Pickler(object):
 
             if reduce_val:
                 try:
-                    # At present, we only handle the case where __reduce__ returns a string
-                    if isinstance(reduce_val, basestring):
+                    # At this stage, we only handle the case where __reduce__ returns a string
+                    # other reduce functionality is implemented further down
+                    if isinstance(reduce_val, (str, unicode)):
                         varpath = iter(reduce_val.split('.'))
                         # curmod will be transformed by the loop into the value to pickle
                         curmod = sys.modules[next(varpath)]
@@ -287,6 +287,9 @@ class Pickler(object):
 
             if has_getnewargs:
                 data[tags.NEWARGS] = self._flatten(obj.__getnewargs__())
+
+            if has_getinitargs:
+                data[tags.INITARGS] = self._flatten(obj.__getinitargs__())
                 
         if has_getstate:
             try:
@@ -318,11 +321,11 @@ class Pickler(object):
             return [self._flatten(v) for v in obj]
         
         if util.is_iterator(obj):
-            data[tags.ITERATOR] = map(self._flatten, islice(obj, self._max_iter))
+            # force list in python 3
+            data[tags.ITERATOR] = list(map(self._flatten, islice(obj, self._max_iter)))
             return data
 
-
-        if reduce_val and not isinstance(reduce_val, basestring):
+        if reduce_val and not isinstance(reduce_val, (str, unicode)):
             # at this point, reduce_val should be some kind of iterable
             # pad out to len 5
             rv_as_list = list(reduce_val)
@@ -330,11 +333,10 @@ class Pickler(object):
             if insufficiency:
                 rv_as_list+=[None]*insufficiency
             
-            # TODO: pickling iterators requires __newobj__ support!
             if rv_as_list[0].__name__ == '__newobj__':
                 rv_as_list[0] = tags.NEWOBJ
 
-            data[tags.REDUCE] = map(self._flatten, rv_as_list)
+            data[tags.REDUCE] = list(map(self._flatten, rv_as_list))
             
             # lift out iterators, so we don't have to iterator and uniterator their content
             # on unpickle
@@ -343,6 +345,8 @@ class Pickler(object):
 
             if data[tags.REDUCE][4]:
                 data[tags.REDUCE][4] = data[tags.REDUCE][4][tags.ITERATOR]
+            
+            return data
 
         if has_dict:
             # Support objects that subclasses list and set

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -11,6 +11,7 @@ from jsonpickle.compat import set
 
 FUNCTION = 'py/function'
 ID = 'py/id'
+INITARGS = 'py/initargs'
 ITERATOR = 'py/iterator'
 JSON_KEY = 'json://'
 NEWARGS = 'py/newargs'
@@ -29,6 +30,7 @@ TYPE = 'py/type'
 RESERVED = set([
     FUNCTION,
     ID,
+    INITARGS,
     ITERATOR,
     NEWARGS,
     NEWOBJ,

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -157,7 +157,9 @@ class Unpickler(object):
 
     def _restore_reduce(self, obj):
         """
-        At present only supports the two required arguments
+        Supports restoring with all elements of __reduce__ as per pep 307. 
+        Assumes that iterator items (the last two) are represented as lists
+        as per pickler implementation.
         """
         reduce_val = obj[tags.REDUCE]
         f, args, state, listitems, dictitems = map(self._restore, reduce_val)
@@ -240,6 +242,7 @@ class Unpickler(object):
     def _restore_object_instance(self, obj, cls):
         factory = self._loadfactory(obj)
         args = getargs(obj)
+        is_oldstyle = not (isinstance(cls, type) or getattr(cls, '__meta__', None))
 
         # This is a placeholder proxy object which allows child objects to
         # reference the parent object before it has been instantiated.
@@ -249,7 +252,7 @@ class Unpickler(object):
         if args:
             args = self._restore(args)
         try:
-            if hasattr(cls, '__new__'): # new style classes
+            if (not is_oldstyle) and hasattr(cls, '__new__'): # new style classes
                 if factory:
                     instance = cls.__new__(cls, factory, *args)
                     instance.default_factory = factory
@@ -258,10 +261,16 @@ class Unpickler(object):
             else:
                 instance = object.__new__(cls)
         except TypeError: # old-style classes
+            is_oldstyle = True
+
+        if is_oldstyle:
             try:
-                instance = cls()
-            except TypeError: # fail gracefully
-                return self._mkref(obj)
+                instance = cls(*args)
+            except TypeError:  # fail gracefully
+                try:
+                    instance = make_blank_classic(cls)
+                except:  # fail gracefully
+                    return self._mkref(obj)
 
         proxy.instance = instance
         self._swapref(proxy, instance)
@@ -466,6 +475,10 @@ def getargs(obj):
     # Let saved newargs take precedence over everything
     if has_tag(obj, tags.NEWARGS):
         return obj[tags.NEWARGS]
+
+    if has_tag(obj, tags.INITARGS):
+        return obj[tags.INITARGS]
+    
     try:
         seq_list = obj[tags.SEQ]
         obj_dict = obj[tags.OBJECT]
@@ -479,6 +492,21 @@ def getargs(obj):
             return seq_list
     return []
 
+
+class _trivialclassic:
+    """
+    A trivial class that can be instantiated with no args
+    """
+
+def make_blank_classic(cls):
+    """
+    Implement the mandated strategy for dealing with classic classes
+    which cannot be instantiated without __getinitargs__ because they
+    take parameters
+    """
+    instance = _trivialclassic()
+    instance.__class__ = cls
+    return instance
 
 def loadrepr(reprstr):
     """Returns an instance of the object from the object's repr() string.

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -9,7 +9,6 @@
 """Helper functions for pickling and unpickling.  Most functions assist in
 determining the type of an object.
 """
-import __builtin__
 import base64
 import collections
 import io
@@ -23,6 +22,8 @@ from jsonpickle.compat import unicode
 from jsonpickle.compat import long
 from jsonpickle.compat import PY3
 
+if not PY3:
+    import __builtin__
 
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = set(SEQUENCES)
@@ -271,9 +272,12 @@ def is_list_like(obj):
 
 
 def is_iterator(obj):
+    is_file = False
+    if not PY3:
+        is_file = isinstance(obj, __builtin__.file)
+
     return (isinstance(obj, collections.Iterator) and 
-            not isinstance(obj, io.IOBase) and 
-            not isinstance(obj, __builtin__.file))
+            not isinstance(obj, io.IOBase) and not is_file)
 
 
 def is_reducible(obj):

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -17,7 +17,7 @@ import jsonpickle
 from jsonpickle import tags, util
 from jsonpickle.compat import unicode
 from jsonpickle.compat import unichr
-from jsonpickle.compat import PY32
+from jsonpickle.compat import PY32, PY3
 
 
 class Thing(object):
@@ -776,7 +776,7 @@ def __newobj__(lol, fail):
 class PickleProtocol2ReduceNewobj(PickleProtocol2ReduceTupleFunc):
 
     def __new__(cls, *args):
-        inst = super(cls, cls).__new__(cls, *args)
+        inst = super(cls, cls).__new__(cls)
         inst.newargs = args
         return inst
 
@@ -873,14 +873,55 @@ class PickleProtocol2ReduceDictitems(object):
     def __setitem__(self, k, v):
         return self.inner.__setitem__(k, v)
 
+class PickleProtocol2Classic:
+
+    def __init__(self, foo):
+        self.foo = foo
+
+
+class PickleProtocol2ClassicInitargs:
+
+    def __init__(self, foo, bar=None):
+        self.foo = foo
+        if bar:
+            self.bar=bar
+
+    def __getinitargs__(self):
+        return ('choo', 'choo')
+
     
 class PicklingProtocol2TestCase(unittest.TestCase):
+
+    def test_classic_init_has_args(self):
+        """
+        Test unpickling a classic instance whose init takes args,
+        has no __getinitargs__
+        Because classic only exists under 2, skipped if PY3
+        """
+        if PY3:
+            self.skipTest('No classic classes in PY3')
+        instance = PickleProtocol2Classic(3)
+        encoded = jsonpickle.encode(instance)
+        decoded = jsonpickle.decode(encoded)
+        self.assertEqual(decoded.foo, 3)
+
+    def test_getinitargs(self):
+        """
+        Test __getinitargs__ with classic instance
+        
+        Because classic only exists under 2, skipped if PY3
+        """
+        if PY3:
+            self.skipTest('No classic classes in PY3')
+        instance = PickleProtocol2ClassicInitargs(3)
+        encoded = jsonpickle.encode(instance)
+        decoded = jsonpickle.decode(encoded)
+        self.assertEqual(decoded.bar, 'choo')
 
     def test_reduce_dictitems(self):
         'Test reduce with dictitems set (as a generator)'
         instance = PickleProtocol2ReduceDictitems()
         encoded = jsonpickle.encode(instance)
-        print encoded
         decoded = jsonpickle.decode(encoded)
         self.assertEqual(decoded.inner, {u'foo': u'foo', u'bar': u'bar'})
 
@@ -888,7 +929,6 @@ class PicklingProtocol2TestCase(unittest.TestCase):
         'Test reduce with listitems set (as a generator), yielding single items'
         instance = PickleProtocol2ReduceListitemsExtend()
         encoded = jsonpickle.encode(instance)
-        # print encoded
         decoded = jsonpickle.decode(encoded)
         self.assertEqual(decoded.inner, ['foo', 'bar'])
 
@@ -896,7 +936,6 @@ class PicklingProtocol2TestCase(unittest.TestCase):
         'Test reduce with listitems set (as a generator), yielding single items'
         instance = PickleProtocol2ReduceListitemsAppend()
         encoded = jsonpickle.encode(instance)
-        # print encoded
         decoded = jsonpickle.decode(encoded)
         self.assertEqual(decoded.inner, ['foo', 'bar'])
         
@@ -962,7 +1001,6 @@ class PicklingProtocol2TestCase(unittest.TestCase):
         instance = PickleProtocol2ReduceNewobj(5)
         encoded = jsonpickle.encode(instance)
         decoded = jsonpickle.decode(encoded)
-        print encoded
         self.assertEqual(decoded.newargs, ('yam', 1))
 
     def test_reduce_iter(self):
@@ -970,7 +1008,6 @@ class PicklingProtocol2TestCase(unittest.TestCase):
         self.assertTrue(util.is_iterator(instance))
         encoded = jsonpickle.encode(instance)
         decoded = jsonpickle.decode(encoded)
-        print encoded
         self.assertEqual(next(decoded), '1')
         self.assertEqual(next(decoded), '2')
         self.assertEqual(next(decoded), '3')


### PR DESCRIPTION
This adds full pickle protocol 2 support:
- `__reduce__` and `__reduce_ex__` may redirect to another object
- Will use `__reduce__` or `__reduce_ex__` if provided, in preference to object `__dict__` or `__slots__`; will not use `__reduce__` or `__reduce_ex__` for special-cased classes, and will not use the default `object` implementations of those methods.
- Adds support for pickling iterators (and adds optional parameter `max_iter` to avoid livelocking on infinite iterators).
- Adds support for `__getinitargs__` and unpickling classic classes which take `__init__` parameters, even if `__getinitargs__` is not provided.

@davvid 
