### PR TITLE
Issue #83: Add support for `__getnewargs_ex__`

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -224,6 +224,7 @@ class Pickler(object):
         has_dict = hasattr(obj, '__dict__')
         has_slots = not has_dict and hasattr(obj, '__slots__')
         has_getnewargs = hasattr(obj, '__getnewargs__')
+        has_getnewargs_ex = hasattr(obj, '__getnewargs_ex__')
         has_getinitargs = hasattr(obj, '__getinitargs__')
         has_reduce, has_reduce_ex = util.has_reduce(obj)
 
@@ -285,7 +286,10 @@ class Pickler(object):
                     # well, we can't do anything with that, so we ignore it
                     pass
 
-            if has_getnewargs:
+            if has_getnewargs_ex:
+                data[tags.NEWARGSEX] = list(map(self._flatten, obj.__getnewargs_ex__()))
+
+            if has_getnewargs and not has_getnewargs_ex:
                 data[tags.NEWARGS] = self._flatten(obj.__getnewargs__())
 
             if has_getinitargs:

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -15,6 +15,7 @@ INITARGS = 'py/initargs'
 ITERATOR = 'py/iterator'
 JSON_KEY = 'json://'
 NEWARGS = 'py/newargs'
+NEWARGSEX = 'py/newargsex'
 NEWOBJ = 'py/newobj'
 OBJECT = 'py/object'
 REDUCE = 'py/reduce'
@@ -33,6 +34,7 @@ RESERVED = set([
     INITARGS,
     ITERATOR,
     NEWARGS,
+    NEWARGSEX,
     NEWOBJ,
     OBJECT,
     REDUCE,


### PR DESCRIPTION
@davvid The easy part of protocol 4 support

OT: I notice that the github pages haven't been updated since 0.70. Maybe a good time to update?
