### PR TITLE
pickler: escape string that have special meaning when used as dictionary key

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -445,17 +445,15 @@ class Pickler(object):
         """Flatten a key/value pair into the passed-in dictionary."""
         if not util.is_picklable(k, v):
             return data
-        if not isinstance(k, (str, unicode)):
-            if self.keys:
-                k = self._escape_string_key(k)
-            else:
+        if self.keys:
+            if not isinstance(k, (str, unicode)) or k.startswith(tags.JSON_KEY):
+                k = self._escape_key(k)
+        else:
+            if not isinstance(k, (str, unicode)):
                 try:
                     k = repr(k)
                 except:
                     k = unicode(k)
-        elif k.startswith(tags.JSON_KEY):
-            if self.keys:
-                k = self._escape_string_key(k)
 
         data[k] = self._flatten(v)
         return data
@@ -471,7 +469,7 @@ class Pickler(object):
             return value
         return data
 
-    def _escape_string_key(self, k):
+    def _escape_key(self, k):
         return tags.JSON_KEY + encode(k,
                                       reset=False, keys=True,
                                       context=self, backend=self.backend,

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -486,6 +486,13 @@ class JSONPickleTestCase(unittest.TestCase):
         unpickled = jsonpickle.decode(pickled, keys=True)
         self.assertEqual(unpickled[tags.JSON_KEY + '6'], [1, 2])
 
+    def test_string_key_not_requiring_escape_dict_keys_with_keys_enabled(self):
+        """ test that string keys that does not require escaping are not escaped """
+        str_dict = {'name': [1, 2]}
+        pickled = jsonpickle.encode(str_dict, keys=True)
+        unpickled = jsonpickle.decode(pickled)
+        self.assertIn('name', unpickled)
+
     def test_list_of_objects(self):
         """Test that objects in lists are referenced correctly"""
         a = Thing('a')


### PR DESCRIPTION
When keys=True, jsonpickle currently encodes

```
In [1]: original = {'json://6': 6}

In [2]: encode(original, keys=True)
Out[2]: '{"json://6": 6}'
```

which when reconstituted becomes:

```
In [3]: decode(encode(original, keys=True), keys=True)
Out[3]: {6: 6}
```

This pull request changes the JSON string to:

```
In [1]: original = {'json://6': 6}

In [2]: encode(original, keys=True)
Out[2]: '{"json://\\"json://6\\"": 6}'
```

which would be correctly reconstituted to:

```
In [3]: decode(encode(original, keys=True), keys=True)
Out[3]: {'json://6': 6}
```

Refer to #90
