### PR TITLE
Fix none key

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -450,10 +450,11 @@ class Pickler(object):
                 k = self._escape_key(k)
         else:
             if not isinstance(k, (str, unicode)):
-                try:
-                    k = repr(k)
-                except:
-                    k = unicode(k)
+                if k is not None:
+                    try:
+                        k = repr(k)
+                    except:
+                        k = unicode(k)
 
         data[k] = self._flatten(v)
         return data

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -446,7 +446,7 @@ class JSONPickleTestCase(unittest.TestCase):
 
     def test_None_dict_key_default(self):
         # We do string coercion for non-string keys so None becomes 'None'
-        expect = {'None': None}
+        expect = {'null': None}
         obj = {None: None}
         pickle = jsonpickle.encode(obj)
         actual = jsonpickle.decode(pickle)


### PR DESCRIPTION
As refered to in #91. This pull request changes the jsonpickled output for

``` python
{None: None}
```

to 

``` json
{"null": null}
```
