### PR TITLE
Basic support for pickling types with metaclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.pyc
+*.py[cod]
 *.egg-info
 *.swp
 *#*
@@ -8,3 +8,5 @@
 /dist
 /env*
 /tags
+__pycache__
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
+python: 2.7
+env:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
 install:
-  - pip install -r requirements-${TRAVIS_PYTHON_VERSION:0:1}.txt
-  - pip install -r requirements-test.txt
+  - pip install tox
 script:
-  - nosetests --with-doctest
+  - tox -e $TOX_ENV

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,8 +1,15 @@
 Change Log
 ==========
-Version 0.8.1 - October TBD, 2014
+Version 0.8.1 - January TBD, 2015
 ---------------------------------
     * Support for Pickle Protocol v4.
+
+    * We now support serializing defaultdict subclasses that use `self`
+      as their default factory.
+
+    * We now have a decorator syntax for registering custom handlers,
+      and allow custom handlers to register themselves for all subclasses.
+      (`#104 <https://github.com/jsonpickle/jsonpickle/pull/104>`_).
 
 Version 0.8.0 - September 6, 2014
 ---------------------------------

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -233,14 +233,14 @@ class Pickler(object):
         has_class = hasattr(obj, '__class__')
         has_dict = hasattr(obj, '__dict__')
         has_slots = not has_dict and hasattr(obj, '__slots__')
-        has_getnewargs = hasattr(obj, '__getnewargs__')
-        has_getnewargs_ex = hasattr(obj, '__getnewargs_ex__')
-        has_getinitargs = hasattr(obj, '__getinitargs__')
+        has_getnewargs = util.has_method(obj, '__getnewargs__')
+        has_getnewargs_ex = util.has_method(obj, '__getnewargs_ex__')
+        has_getinitargs = util.has_method(obj, '__getinitargs__')
         has_reduce, has_reduce_ex = util.has_reduce(obj)
 
         # Support objects with __getstate__(); this ensures that
         # both __setstate__() and __getstate__() are implemented
-        has_getstate = hasattr(obj, '__getstate__')
+        has_getstate = util.has_method(obj, '__getstate__')
 
         if has_class:
             cls = obj.__class__

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -240,7 +240,8 @@ class Pickler(object):
 
         # Support objects with __getstate__(); this ensures that
         # both __setstate__() and __getstate__() are implemented
-        has_getstate = util.has_method(obj, '__getstate__')
+        has_getstate = hasattr(obj, '__getstate__')
+        # not using has_method since __getstate__() is handled separately below
 
         if has_class:
             cls = obj.__class__

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -403,15 +403,17 @@ class Unpickler(object):
         # instead of doing so in the body of the function to
         # avoid conditional branching inside a tight loop.
         if self.keys:
-            def restore_key(key):
-                if key.startswith(tags.JSON_KEY):
-                    key = decode(key[len(tags.JSON_KEY):],
-                                 backend=self.backend, context=self,
-                                 keys=True, reset=False)
-                return key
+            restore_key = self._restore_pickled_key
         else:
             restore_key = lambda key: key
         return restore_key
+
+    def _restore_pickled_key(self, key):
+        if key.startswith(tags.JSON_KEY):
+            key = decode(key[len(tags.JSON_KEY):],
+                         backend=self.backend, context=self,
+                         keys=True, reset=False)
+        return key
 
     def _refname(self):
         """Calculates the name of the current location in the JSON stack.

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -63,6 +63,9 @@ class _Proxy(object):
     def __init__(self):
         self.instance = None
 
+    def __call__(self):
+        return self.instance()
+
 
 def _obj_setattr(obj, attr, proxy):
     setattr(obj, attr, proxy.instance)
@@ -240,7 +243,6 @@ class Unpickler(object):
         return self._restore(default_factory)
 
     def _restore_object_instance(self, obj, cls):
-        factory = self._loadfactory(obj)
         if has_tag(obj, tags.NEWARGSEX):
             args, kwargs = obj[tags.NEWARGSEX]
         else:
@@ -253,6 +255,10 @@ class Unpickler(object):
         # reference the parent object before it has been instantiated.
         proxy = _Proxy()
         self._mkref(proxy)
+
+        # An object can install itself as its own factory, so load the factory
+        # after the instance is available for referencing.
+        factory = self._loadfactory(obj)
 
         if args:
             args = self._restore(args)

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -243,14 +243,6 @@ class Unpickler(object):
         return self._restore(default_factory)
 
     def _restore_object_instance(self, obj, cls):
-        if has_tag(obj, tags.NEWARGSEX):
-            args, kwargs = obj[tags.NEWARGSEX]
-        else:
-            args = getargs(obj)
-            kwargs = {}
-
-        is_oldstyle = not (isinstance(cls, type) or getattr(cls, '__meta__', None))
-
         # This is a placeholder proxy object which allows child objects to
         # reference the parent object before it has been instantiated.
         proxy = _Proxy()
@@ -260,10 +252,17 @@ class Unpickler(object):
         # after the instance is available for referencing.
         factory = self._loadfactory(obj)
 
+        if has_tag(obj, tags.NEWARGSEX):
+            args, kwargs = obj[tags.NEWARGSEX]
+        else:
+            args = getargs(obj)
+            kwargs = {}
         if args:
             args = self._restore(args)
         if kwargs:
             kwargs = self._restore(kwargs)
+
+        is_oldstyle = not (isinstance(cls, type) or getattr(cls, '__meta__', None))
         try:
             if (not is_oldstyle) and hasattr(cls, '__new__'):  # new style classes
                 if factory:

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -43,10 +43,19 @@ def is_type(obj):
     >>> is_type(Klass)
     True
     """
+    # use "isinstance" and not "is" to allow for metaclasses
     if PY3:
-        return type(obj) is type
+        return isinstance(obj, type)
     else:
-        return type(obj) is type or type(obj) is types.ClassType
+        return isinstance(obj, (type, types.ClassType))
+
+
+def has_method(obj, name, *args, **kwargs):
+    try:
+        getattr(obj, name)(*args, **kwargs)
+        return True
+    except:
+        return False
 
 
 def is_object(obj):
@@ -62,8 +71,7 @@ def is_object(obj):
     False
     """
     return (isinstance(obj, object) and
-            type(obj) is not type and
-            type(obj) is not types.FunctionType)
+            not isinstance(obj, (type, types.FunctionType)))
 
 
 def is_primitive(obj):
@@ -82,6 +90,7 @@ def is_primitive(obj):
         return True
     return False
 
+
 def is_dictionary(obj):
     """Helper method for testing if the object is a dictionary.
 
@@ -90,6 +99,7 @@ def is_dictionary(obj):
 
     """
     return type(obj) is dict
+
 
 def is_sequence(obj):
     """Helper method to see if the object is a sequence (list, set, or tuple).
@@ -214,7 +224,7 @@ def is_module_function(obj):
     """
 
     return (hasattr(obj, '__class__') and
-            obj.__class__ is types.FunctionType and
+            isinstance(obj, types.FunctionType) and
             hasattr(obj, '__module__') and
             hasattr(obj, '__name__') and
             obj.__name__ != '<lambda>')
@@ -228,7 +238,7 @@ def is_module(obj):
     True
 
     """
-    return type(obj) is types.ModuleType
+    return isinstance(obj, types.ModuleType)
 
 
 def is_picklable(name, value):

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -23,11 +23,11 @@ class CustomObject(object):
         return self.name == other.name
 
 
-class A(CustomObject):
+class CustomA(CustomObject):
     pass
 
 
-class B(A):
+class CustomB(CustomA):
     pass
 
 
@@ -95,21 +95,21 @@ class HandlerTestCase(unittest.TestCase):
         self.assertRaises(TypeError, jsonpickle.handlers.register, 'foo', NullHandler)
 
     def test_base_handler(self):
-        a = A('a')
+        a = CustomA('a')
         self.assertTrue(a.creator is None)
         self.assertTrue(jsonpickle.decode(jsonpickle.encode(a)).creator is None)
 
-        b = B('b')
+        b = CustomB('b')
         self.assertTrue(b.creator is None)
         self.assertTrue(jsonpickle.decode(jsonpickle.encode(b)).creator is None)
 
         OtherHandler = type('OtherHandler', (NullHandler,), {})
-        jsonpickle.handlers.register(A, OtherHandler, base=True)
+        jsonpickle.handlers.register(CustomA, OtherHandler, base=True)
         self.assertTrue(self.roundtrip(a).creator is OtherHandler)
         self.assertTrue(self.roundtrip(b).creator is OtherHandler)
 
         SpecializedHandler = type('SpecializedHandler', (NullHandler,), {})
-        jsonpickle.handlers.register(B, SpecializedHandler)
+        jsonpickle.handlers.register(CustomB, SpecializedHandler)
         self.assertTrue(self.roundtrip(a).creator is OtherHandler)
         self.assertTrue(self.roundtrip(b).creator is SpecializedHandler)
 

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -153,6 +153,26 @@ class ThingWithStringSlots(object):
         self.ab = a + b
 
 
+class ThingWithSelfAsDefaultFactory(collections.defaultdict):
+    """defaultdict subclass that uses itself as its default factory"""
+
+    def __init__(self):
+        self.default_factory = self
+
+    def __call__(self):
+        return self.__class__()
+
+
+class ThingWithClassAsDefaultFactory(collections.defaultdict):
+    """defaultdict subclass that uses its class as its default factory"""
+
+    def __init__(self):
+        self.default_factory = self.__class__
+
+    def __call__(self):
+        return self.__class__()
+
+
 class AdvancedObjectsTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -197,6 +217,32 @@ class AdvancedObjectsTestCase(unittest.TestCase):
         self.assertEqual(newdefaultdict[2][0], 0) # outer defaultdict
         self.assertEqual(type(newdefaultdict[3]), collections.defaultdict)
         self.assertEqual(newdefaultdict[3].default_factory, int) # outer-most defaultdict
+
+    def test_defaultdict_subclass_with_self_as_default_factory(self):
+        tree = ThingWithSelfAsDefaultFactory()
+        self._test_defaultdict_tree(tree, ThingWithSelfAsDefaultFactory)
+
+    def test_defaultdict_subclass_with_class_as_default_factory(self):
+        tree = ThingWithClassAsDefaultFactory()
+        self._test_defaultdict_tree(tree, ThingWithClassAsDefaultFactory)
+
+    def _test_defaultdict_tree(self, tree, cls):
+        tree['A']['B'] = 1
+        tree['A']['C'] = 2
+        # roundtrip
+        encoded = jsonpickle.encode(tree)
+        newtree = jsonpickle.decode(encoded)
+        # make sure we didn't lose anything
+        self.assertEqual(type(newtree), cls)
+        self.assertEqual(type(newtree['A']), cls)
+        self.assertEqual(newtree['A']['B'], 1)
+        self.assertEqual(newtree['A']['C'], 2)
+        # ensure that the resulting default_factory is callable and creates
+        # a new instance of cls.
+        self.assertEqual(type(newtree['A'].default_factory()), cls)
+        # we've never seen 'D' before so the reconstructed defaultdict tree
+        # should create an instance of cls.
+        self.assertEqual(type(newtree['A']['D']), cls)
 
     def test_deque_roundtrip(self):
         """Make sure we can handle collections.deque"""

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -172,9 +172,9 @@ class UtilTestCase(unittest.TestCase):
 
     def test_has_method(self):
         foo = Foo()
-        self.assertTrue(util.has_method(foo, "f", 1))
-        self.assertFalse(util.has_method(foo, "f"))
-        self.assertFalse(util.has_method(Foo, "f", 1))
+        self.assertTrue(jsonpickle.util.has_method(foo, "f", 1))
+        self.assertFalse(jsonpickle.util.has_method(foo, "f"))
+        self.assertFalse(jsonpickle.util.has_method(Foo, "f", 1))
 
 
 def suite():

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -31,8 +31,27 @@ class ListSubclass(list):
     pass
 
 
-class Foo(object):
-    def f(self, x):
+class MethodTestClass(object):
+    @staticmethod
+    def static_method():
+        pass
+
+    @classmethod
+    def class_method(cls):
+        pass
+
+    def bound_method(self):
+        pass
+
+    variable = None
+
+
+class MethodTestSubclass(MethodTestClass):
+    pass
+
+
+class MethodTestOldStyle:
+    def bound_method(self):
         pass
 
 
@@ -73,7 +92,7 @@ class UtilTestCase(unittest.TestCase):
         self.assertFalse(util.is_primitive([4, 4]))
 
     def test_is_primitive_dict(self):
-        self.assertFalse(util.is_primitive({'key':'value'}))
+        self.assertFalse(util.is_primitive({'key': 'value'}))
         self.assertFalse(util.is_primitive({}))
 
     def test_is_primitive_tuple(self):
@@ -96,9 +115,9 @@ class UtilTestCase(unittest.TestCase):
         self.assertTrue(util.is_tuple((1, 2)))
 
     def test_is_list_dict(self):
-        self.assertFalse(util.is_list({'key':'value'}))
-        self.assertFalse(util.is_set({'key':'value'}))
-        self.assertFalse(util.is_tuple({'key':'value'}))
+        self.assertFalse(util.is_list({'key': 'value'}))
+        self.assertFalse(util.is_set({'key': 'value'}))
+        self.assertFalse(util.is_tuple({'key': 'value'}))
 
     def test_is_list_other(self):
         self.assertFalse(util.is_list(1))
@@ -171,10 +190,42 @@ class UtilTestCase(unittest.TestCase):
         self.assertEqual(expect, actual)
 
     def test_has_method(self):
-        foo = Foo()
-        self.assertTrue(jsonpickle.util.has_method(foo, "f", 1))
-        self.assertFalse(jsonpickle.util.has_method(foo, "f"))
-        self.assertFalse(jsonpickle.util.has_method(Foo, "f", 1))
+        instance = MethodTestClass()
+        x = 1
+        has_method = jsonpickle.util.has_method
+
+        # no attribute
+        self.assertFalse(has_method(instance, 'foo'))
+
+        # builtin method type
+        self.assertFalse(has_method(int, '__getnewargs__'))
+        self.assertTrue(has_method(x, '__getnewargs__'))
+
+        # staticmethod
+        self.assertTrue(has_method(instance, 'static_method'))
+        self.assertTrue(has_method(MethodTestClass, 'static_method'))
+
+        # not a method
+        self.assertFalse(has_method(instance, 'variable'))
+        self.assertFalse(has_method(MethodTestClass, 'variable'))
+
+        # classmethod
+        self.assertTrue(has_method(instance, 'class_method'))
+        self.assertTrue(has_method(MethodTestClass, 'class_method'))
+
+        # bound method
+        self.assertTrue(has_method(instance, 'bound_method'))
+        self.assertFalse(has_method(MethodTestClass, 'bound_method'))
+
+        # subclass bound method
+        sub_instance = MethodTestSubclass()
+        self.assertTrue(has_method(sub_instance, 'bound_method'))
+        self.assertFalse(has_method(MethodTestSubclass, 'bound_method'))
+
+        # old style object
+        old_instance = MethodTestOldStyle()
+        self.assertTrue(has_method(old_instance, 'bound_method'))
+        self.assertFalse(has_method(MethodTestOldStyle, 'bound_method'))
 
 
 def suite():

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -31,6 +31,11 @@ class ListSubclass(list):
     pass
 
 
+class Foo(object):
+    def f(self, x):
+        pass
+
+
 class UtilTestCase(unittest.TestCase):
 
     def test_is_primitive_int(self):
@@ -164,6 +169,12 @@ class UtilTestCase(unittest.TestCase):
         expect = '0'
         actual = util.itemgetter((0, 'zero'))
         self.assertEqual(expect, actual)
+
+    def test_has_method(self):
+        foo = Foo()
+        self.assertTrue(util.has_method(foo, "f", 1))
+        self.assertFalse(util.has_method(foo, "f"))
+        self.assertFalse(util.has_method(Foo, "f", 1))
 
 
 def suite():

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py{26,27,33,34}
+minversion = 1.8
+
+[testenv]
+changedir = tests
+deps =
+    nose
+    coverage
+    feedparser
+    simplejson
+    ujson
+    py{26,27}: demjson
+    py{26,27}: jsonlib
+    py{26,27}: yajl
+    py{26,27,33}: enum34
+commands =
+    nosetests --with-doctest {posargs}


### PR DESCRIPTION
This now works out of the box on both Python 2 and Python 3:
```python
>>> import enum
>>> class Foo(enum.IntEnum):
...     A = 1
...     B = 2
... 
>>> import jsonpickle
>>> jsonpickle.encode(Foo.A)
'{"py/reduce": [{"py/type": "__main__.Foo"}, {"py/tuple": [1]}, null, null, null], "py/object": "__main__.Foo", "py/newargs": {"py/tuple": [1]}}'
>>> jsonpickle.decode(jsonpickle.encode(Foo.A))
<Foo.A: 1>
```
There were two problems about this: `has_get*` flags in `_flatten_obj_instance` were not set correctly and `util.is_type` was returning false for types with metaclasses.

There may be some unobvious edge cases with twisted usage of metaclasses, but it at the very least seems to handle `enum` which is not the simplest example of all (https://hg.python.org/cpython/file/3.4/Lib/enum.py).