### PR TITLE
Add deque maxlen support

### DIFF
--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -232,6 +232,7 @@ class OrderedDictReduceHandler(SimpleReduceHandler):
 
 SimpleReduceHandler.handles(time.struct_time)
 SimpleReduceHandler.handles(datetime.timedelta)
+SimpleReduceHandler.handles(collections.deque)
 if sys.version_info >= (2, 7):
     SimpleReduceHandler.handles(collections.Counter)
     if sys.version_info >= (3, 4):

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -288,7 +288,7 @@ class AdvancedObjectsTestCase(SkippableTest):
 
     def test_deque_roundtrip(self):
         """Make sure we can handle collections.deque"""
-        old_deque = collections.deque([0, 1, 2])
+        old_deque = collections.deque([0, 1, 2], maxlen=5)
         encoded = jsonpickle.encode(old_deque)
         new_deque = jsonpickle.decode(encoded)
         self.assertNotEqual(encoded, 'nil')
@@ -298,6 +298,8 @@ class AdvancedObjectsTestCase(SkippableTest):
         self.assertEqual(new_deque[1], 1)
         self.assertEqual(old_deque[2], 2)
         self.assertEqual(new_deque[2], 2)
+        self.assertEqual(old_deque.maxlen, 5)
+        self.assertEqual(new_deque.maxlen, 5)
 
     def test_namedtuple_roundtrip(self):
         old_nt = NamedTuple(0, 1, 2)


### PR DESCRIPTION
Using SimpleReduceHandler preserves the maxlen parameter of deques on decode, as per #121.