### PR TITLE
Expand on installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,19 @@ Install from pip for the latest stable release:
 
     pip install jsonpickle
 
-Install from source for the latest changes:
+Install from github for the latest changes:
+
+::
+
+    pip install git+https://github.com/jsonpickle/jsonpickle.git
+
+If you have the files checked out for development:
 
 ::
 
     git clone https://github.com/jsonpickle/jsonpickle.git
     cd jsonpickle
-    python setup.py install
+    python setup.py develop
 
 
 jsonpickleJS

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,20 @@ Bug reports and merge requests are encouraged at the
 Install
 =======
 
+Install from pip for the latest stable release:
+
 ::
 
+    pip install jsonpickle
+
+Install from source for the latest changes:
+
+::
+
+    git clone https://github.com/jsonpickle/jsonpickle.git
+    cd jsonpickle
     python setup.py install
+
 
 jsonpickleJS
 ============


### PR DESCRIPTION
Having a 'pip install' example is a nice-to-have to get developers up and running quickly when someone hits the github page. I guess you might notice the setup.py and think that it might already exist, but it isn't immediately presented as an option. 