### PR TITLE
Support backend decoder options equal to encoder options

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,6 +57,8 @@ Experimental backends:
 
 .. autofunction:: jsonpickle.set_encoder_options
 
+.. autofunction:: jsonpickle.set_decoder_options
+
 Customizing JSON output
 -----------------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,9 @@ Unreleased Version 0.9.3 - TBD
     * UUID objects can now be serialized
       (`#130 <https://github.com/jsonpickle/jsonpickle/issues/130>`_).
 
+    * Added `set_decoder_options` method to allow decoder specific options
+      equal to `set_encoder_options`.
+
 Version 0.9.2 - March 20, 2015
 ------------------------------
     * Fixes for serializing objects with custom handlers.

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -68,6 +68,7 @@ json = JSONBackend()
 
 # Export specific JSONPluginMgr methods into the jsonpickle namespace
 set_preferred_backend = json.set_preferred_backend
+set_decoder_options = json.set_decoder_options
 set_encoder_options = json.set_encoder_options
 load_backend = json.load_backend
 remove_backend = json.remove_backend

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -129,7 +129,8 @@ def encode(value,
                           make_refs=make_refs,
                           keys=keys,
                           max_depth=max_depth,
-                          warn=warn)
+                          warn=warn,
+                          max_iter=max_iter)
 
 
 def decode(string, backend=None, keys=False):

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -161,10 +161,7 @@ class JSONBackend(object):
 
         for idx, name in enumerate(self._backend_names):
             try:
-                optargs, optkwargs = self._encoder_options[name]
-                encoder_kwargs = optkwargs.copy()
-                encoder_args = (obj,) + tuple(optargs)
-                return self._encoders[name](*encoder_args, **encoder_kwargs)
+                return self.backend_encode(name, obj)
             except Exception as e:
                 if idx == len(self._backend_names) - 1:
                     raise e

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -33,6 +33,9 @@ class JSONBackend(object):
             'django.util.simplejson': json_opts,
         }
 
+        # Options to pass to specific encoders
+        self._decoder_options = {}
+
         # The exception class that is thrown when a decoding error occurs
         self._decoder_exceptions = {}
 
@@ -120,8 +123,9 @@ class JSONBackend(object):
             # simplejson uses ValueError
             self._decoder_exceptions[name] = loads_exc
 
-        # Setup the default args and kwargs for this encoder
+        # Setup the default args and kwargs for this encoder/decoder
         self._encoder_options[name] = ([], {})
+        self._decoder_options[name] = ([], {})
 
         # Add this backend to the list of candidate backends
         self._backend_names.append(name)
@@ -135,6 +139,7 @@ class JSONBackend(object):
         self._encoders.pop(name, None)
         self._decoders.pop(name, None)
         self._decoder_exceptions.pop(name, None)
+        self._decoder_options.pop(name, None)
         self._encoder_options.pop(name, None)
         if name in self._backend_names:
             self._backend_names.remove(name)
@@ -198,7 +203,9 @@ class JSONBackend(object):
     loads = decode
 
     def backend_decode(self, name, string):
-        return self._decoders[name](string)
+        optargs, optkwargs = self._decoder_options.get(name, ((), {}))
+        decoder_kwargs = optkwargs.copy()
+        return self._decoders[name](string, *optargs, **decoder_kwargs)
 
     def set_preferred_backend(self, name):
         """
@@ -243,6 +250,25 @@ class JSONBackend(object):
 
         """
         self._encoder_options[name] = (args, kwargs)
+
+    def set_decoder_options(self, name, *args, **kwargs):
+        """
+        Associate decoder-specific options with a decoder.
+
+        After calling set_decoder_options, any calls to jsonpickle's
+        decode method will pass the supplied args and kwargs along to
+        the appropriate backend's decode method.
+
+        For example::
+
+            set_decoder_options('simplejson', encoding='utf8', cls=JSONDecoder)
+            set_decoder_options('demjson', strict=True)
+
+        See the appropriate decoder's documentation for details about
+        the supported arguments and keyword arguments.
+
+        """
+        self._decoder_options[name] = (args, kwargs)
 
     def _store(self, dct, backend, obj, name):
         try:


### PR DESCRIPTION
I added a method to support decoder options. While I was at it saw some repeated code and that one argument was not passed on.

Did not see any tests for the encoder but am happy to write one for the decoder if you insist.