### PR TITLE
fixed serialization of fortran ordered base arrays

### DIFF
--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -135,7 +135,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
             data = super(NumpyNDArrayHandlerBinary, self).flatten(obj, data)
         else:
             # encode as binary
-            buffer = obj.tobytes(order=None)    # store as C or Fortran order
+            buffer = obj.tobytes(order='a')	 # numpy docstring is lacking as of 1.11.2, but this is the option we need
             if self.compression:
                 buffer = self.compression.compress(buffer)
             data['values'] = jsonpickle.util.b64encode(buffer)

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -236,6 +236,12 @@ class NumpyTestCase(SkippableTest):
             npt.assert_array_equal(a, _a)
             npt.assert_array_equal(b, _b)
 
+    def test_fortran_base(self):
+        """Test a base array in fortran order"""
+        a = np.asfortranarray(np.arange(100).reshape((10, 10)))
+        _a = self.roundtrip(a)
+        npt.assert_array_equal(a, _a)
+
     def test_buffer(self):
         """test behavior with memoryviews which are not ndarrays"""
         bstring = 'abcdefgh'.encode('utf-8')


### PR DESCRIPTION
this had a critical bug due to an incorrect numpy docstring

Id love to see a patch / release for this asap, as this is a really bad bug