### PR TITLE
made internal imports relative for the sake of easy submodule inclusion.

### DIFF
--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -53,13 +53,13 @@ added to JSON::
     assert obj.name == result['name'] == 'Awesome'
 
 """
-from jsonpickle import pickler
-from jsonpickle import unpickler
-from jsonpickle.backend import JSONBackend
-from jsonpickle.version import VERSION
+from . import pickler
+from . import unpickler
+from .backend import JSONBackend
+from .version import VERSION
 
 # ensure built-in handlers are loaded
-__import__('jsonpickle.handlers')
+from . import handlers as _
 
 __all__ = ('encode', 'decode')
 __version__ = VERSION

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from jsonpickle.compat import PY32
-from jsonpickle.compat import unicode
+from .compat import PY32
+from .compat import unicode
 
 
 class JSONBackend(object):

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -9,8 +9,9 @@ import warnings
 import numpy as np
 
 import ast
-import jsonpickle
-from jsonpickle.compat import unicode
+from ..handlers import BaseHandler, register, unregister
+from ..compat import unicode
+from ..util import b64decode, b64encode
 
 __all__ = ['register_handlers', 'unregister_handlers']
 
@@ -22,7 +23,7 @@ def get_byteorder(arr):
     return native_byteorder if byteorder == '=' else byteorder
 
 
-class NumpyBaseHandler(jsonpickle.handlers.BaseHandler):
+class NumpyBaseHandler(BaseHandler):
 
     def flatten_dtype(self, dtype, data):
         if hasattr(dtype, 'tostring'):
@@ -138,7 +139,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
             buffer = obj.tobytes(order='a')	 # numpy docstring is lacking as of 1.11.2, but this is the option we need
             if self.compression:
                 buffer = self.compression.compress(buffer)
-            data['values'] = jsonpickle.util.b64encode(buffer)
+            data['values'] = b64encode(buffer)
             data['shape'] = obj.shape
             self.flatten_dtype(obj.dtype.newbyteorder('N'), data)
             self.flatten_byteorder(obj, data)
@@ -157,7 +158,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
             arr = super(NumpyNDArrayHandlerBinary, self).restore(data)
         else:
             # decode binary representation
-            buffer = jsonpickle.util.b64decode(values)
+            buffer = b64decode(values)
             if self.compression:
                 buffer = self.compression.decompress(buffer)
             arr = np.ndarray(
@@ -272,12 +273,12 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
 
 
 def register_handlers():
-    jsonpickle.handlers.register(np.dtype, NumpyDTypeHandler, base=True)
-    jsonpickle.handlers.register(np.generic, NumpyGenericHandler, base=True)
-    jsonpickle.handlers.register(np.ndarray, NumpyNDArrayHandlerView(), base=True)
+    register(np.dtype, NumpyDTypeHandler, base=True)
+    register(np.generic, NumpyGenericHandler, base=True)
+    register(np.ndarray, NumpyNDArrayHandlerView(), base=True)
 
 
 def unregister_handlers():
-    jsonpickle.handlers.unregister(np.dtype)
-    jsonpickle.handlers.unregister(np.generic)
-    jsonpickle.handlers.unregister(np.ndarray)
+    unregister(np.dtype)
+    unregister(np.generic)
+    unregister(np.ndarray)

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -31,9 +31,9 @@ import sys
 import time
 import uuid
 
-from jsonpickle import util
-from jsonpickle.compat import unicode
-from jsonpickle.compat import queue
+from . import util
+from .compat import unicode
+from .compat import queue
 
 
 class Registry(object):

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -12,12 +12,12 @@ import warnings
 import sys
 from itertools import chain, islice
 
-import jsonpickle.util as util
-import jsonpickle.tags as tags
-import jsonpickle.handlers as handlers
+from . import util
+from . import tags
+from . import handlers
 
-from jsonpickle.backend import JSONBackend
-from jsonpickle.compat import numeric_types, unicode, PY3, PY2
+from .backend import JSONBackend
+from .compat import numeric_types, unicode, PY3, PY2
 
 
 def encode(value,

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -8,7 +8,7 @@ created by the Pickler class.  The Unpickler uses
 these custom key names to identify dictionaries
 that need to be specially handled.
 """
-from jsonpickle.compat import set
+from .compat import set
 
 
 BYTES = 'py/bytes'

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -11,12 +11,12 @@ import base64
 import quopri
 import sys
 
-import jsonpickle.util as util
-import jsonpickle.tags as tags
-import jsonpickle.handlers as handlers
+from . import util
+from . import tags
+from . import handlers
 
-from jsonpickle.compat import numeric_types, set, unicode
-from jsonpickle.backend import JSONBackend
+from .compat import numeric_types, set, unicode
+from .backend import JSONBackend
 
 
 def decode(string, backend=None, context=None, keys=False, reset=True,

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -17,8 +17,8 @@ import time
 import types
 import inspect
 
-from jsonpickle import tags
-from jsonpickle.compat import set, unicode, long, bytes, PY3
+from . import tags
+from .compat import set, unicode, long, bytes, PY3
 
 if not PY3:
     import __builtin__


### PR DESCRIPTION
The rationale for this change is the following. If somebody wants to include jsonpickle within a repository and directly import from this new location (eg. pkg_foo.libs.jsonpickle), this is not yet possible, because all internal import are absolute to the "jsonpickle" package.

I know that there are concerns using relative imports, but it is actually the only way to make the package relocatable within another package.

https://stackoverflow.com/questions/4209641/absolute-vs-explicit-relative-import-of-python-module
