### PR TITLE
Eliminate simplereduce

### DIFF
--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -35,8 +35,6 @@ from .compat import queue
 from .compat import unicode
 
 
-
-
 class Registry(object):
 
     def __init__(self):
@@ -199,68 +197,8 @@ class RegexHandler(BaseHandler):
     def restore(self, data):
         return re.compile(data['pattern'])
 
+
 RegexHandler.handles(type(re.compile('')))
-
-
-
-class SimpleReduceHandler(BaseHandler):
-    """Follow the __reduce__ protocol to pickle an object.
-
-    As long as the factory and its arguments are pickleable, this should
-    pickle any object that implements the reduce protocol.
-
-    """
-    def flatten(self, obj, data):
-        flatten = self.context.flatten
-        data['__reduce__'] = [flatten(i, reset=False) for i in obj.__reduce__()]
-        return data
-
-    def restore(self, data):
-        # import here to avoid circular imports
-        from .unpickler import Unpickler
-        return Unpickler()._restore_reduce(data)
-
-
-class OrderedDictReduceHandler(SimpleReduceHandler):
-    """Serialize OrderedDict on Python 3.4+
-
-    Python 3.4+ returns multiple entries in an OrderedDict's
-    reduced form.  Previous versions return a two-item tuple.
-    OrderedDictReduceHandler makes the formats compatible.
-
-    """
-    def flatten(self, obj, data):
-        # __reduce__() on older pythons returned a list of
-        # [key, value] list pairs inside a tuple.
-        # Recreate that structure so that the file format
-        # is consistent between python versions.
-        flatten = self.context.flatten
-        reduced = obj.__reduce__()
-        factory = flatten(reduced[0], reset=False)
-        pairs = [list(x) for x in reduced[-1]]
-        args = flatten((pairs,), reset=False)
-        data['__reduce__'] = [factory, args]
-        return data
-
-
-# SimpleReduceHandler.handles(time.struct_time)
-# SimpleReduceHandler.handles(datetime.timedelta)
-# SimpleReduceHandler.handles(collections.deque)
-# if sys.version_info >= (2, 7):
-#     SimpleReduceHandler.handles(collections.Counter)
-#     if sys.version_info >= (3, 4):
-#         OrderedDictReduceHandler.handles(collections.OrderedDict)
-#     else:
-#         SimpleReduceHandler.handles(collections.OrderedDict)
-
-# if sys.version_info >= (3, 0):
-#     SimpleReduceHandler.handles(decimal.Decimal)
-
-# try:
-#     import posix
-#     SimpleReduceHandler.handles(posix.stat_result)
-# except ImportError:
-#     pass
 
 
 class QueueHandler(BaseHandler):

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
-# Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com)
+# Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com) and contributors
 # All rights reserved.
 #
 # This software is licensed as described in the file COPYING, which

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -283,14 +283,18 @@ class Pickler(object):
             return handler(self).flatten(obj, data)
 
         reduce_val = None
-        if has_class and not util.is_module(obj):
-            if self.unpicklable:
-                class_name = util.importable_name(cls)
-                data[tags.OBJECT] = class_name
 
-            # test for a reduce implementation, and redirect before doing anything else
-            # if that is what reduce requests
-            if has_reduce_ex:
+        if has_reduce:
+                try:
+                    reduce_val = obj.__reduce__()
+                except TypeError:
+                    # A lot of builtin types have a reduce which just raises a TypeError
+                    # we ignore those
+                    pass
+
+        # test for a reduce implementation, and redirect before doing anything else
+        # if that is what reduce requests
+        if has_reduce_ex:
                 try:
                     # we're implementing protocol 2
                     reduce_val = obj.__reduce_ex__(2)
@@ -299,19 +303,8 @@ class Pickler(object):
                     # we ignore those
                     pass
 
-            if has_reduce and not reduce_val:
+        if reduce_val and isinstance(reduce_val, (str, unicode)):
                 try:
-                    reduce_val = obj.__reduce__()
-                except TypeError:
-                    # A lot of builtin types have a reduce which just raises a TypeError
-                    # we ignore those
-                    pass
-
-            if reduce_val:
-                try:
-                    # At this stage, we only handle the case where __reduce__ returns a string
-                    # other reduce functionality is implemented further down
-                    if isinstance(reduce_val, (str, unicode)):
                         varpath = iter(reduce_val.split('.'))
                         # curmod will be transformed by the loop into the value to pickle
                         curmod = sys.modules[next(varpath)]
@@ -322,6 +315,37 @@ class Pickler(object):
                 except KeyError:
                     # well, we can't do anything with that, so we ignore it
                     pass
+        
+        elif reduce_val:
+            # at this point, reduce_val should be some kind of iterable
+            # pad out to len 5
+            rv_as_list = list(reduce_val)
+            insufficiency = 5 - len(rv_as_list)
+            if insufficiency:
+                rv_as_list += [None] * insufficiency
+
+            if rv_as_list[0].__name__ == '__newobj__':
+                rv_as_list[0] = tags.NEWOBJ
+
+            f, args, state, listitems, dictitems = rv_as_list
+
+            # check that getstate/setstate is sane
+            if not (state and hasattr(obj, '__getstate__') and not hasattr(obj, '__setstate__') and not isinstance(obj, dict)):
+                # turn iterators to iterables for convenient serialization
+                if rv_as_list[3]:
+                    rv_as_list[3] = tuple(rv_as_list[3])
+
+                if rv_as_list[4]:
+                    rv_as_list[4] = tuple(rv_as_list[4])
+
+                data[tags.REDUCE] = list(map(self._flatten, rv_as_list))
+
+                return data
+                
+        if has_class and not util.is_module(obj):
+            if self.unpicklable:
+                class_name = util.importable_name(cls)
+                data[tags.OBJECT] = class_name
 
             if has_getnewargs_ex:
                 data[tags.NEWARGSEX] = list(map(self._flatten, obj.__getnewargs_ex__()))
@@ -364,29 +388,6 @@ class Pickler(object):
         if util.is_iterator(obj):
             # force list in python 3
             data[tags.ITERATOR] = list(map(self._flatten, islice(obj, self._max_iter)))
-            return data
-
-        if reduce_val and not isinstance(reduce_val, (str, unicode)):
-            # at this point, reduce_val should be some kind of iterable
-            # pad out to len 5
-            rv_as_list = list(reduce_val)
-            insufficiency = 5 - len(rv_as_list)
-            if insufficiency:
-                rv_as_list += [None] * insufficiency
-
-            if rv_as_list[0].__name__ == '__newobj__':
-                rv_as_list[0] = tags.NEWOBJ
-
-            data[tags.REDUCE] = list(map(self._flatten, rv_as_list))
-
-            # lift out iterators, so we don't have to iterator and uniterator their content
-            # on unpickle
-            if data[tags.REDUCE][3]:
-                data[tags.REDUCE][3] = data[tags.REDUCE][3][tags.ITERATOR]
-
-            if data[tags.REDUCE][4]:
-                data[tags.REDUCE][4] = data[tags.REDUCE][4][tags.ITERATOR]
-
             return data
 
         if has_dict:

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -289,29 +289,32 @@ class Pickler(object):
                 try:
                     reduce_val = obj.__reduce__()
                 except TypeError:
-                    # A lot of builtin types have a reduce which just raises a TypeError
+                    # A lot of builtin types have a reduce which
+                    # just raises a TypeError
                     # we ignore those
                     pass
 
-        # test for a reduce implementation, and redirect before doing anything else
-        # if that is what reduce requests
+            # test for a reduce implementation, and redirect before
+            # doing anything else if that is what reduce requests
             elif has_reduce_ex:
                 try:
                     # we're implementing protocol 2
                     reduce_val = obj.__reduce_ex__(2)
                 except TypeError:
-                    # A lot of builtin types have a reduce which just raises a TypeError
+                    # A lot of builtin types have a reduce which
+                    # just raises a TypeError
                     # we ignore those
                     pass
 
             if reduce_val and isinstance(reduce_val, (str, unicode)):
                 try:
-                        varpath = iter(reduce_val.split('.'))
-                        # curmod will be transformed by the loop into the value to pickle
-                        curmod = sys.modules[next(varpath)]
-                        for modname in varpath:
-                            curmod = getattr(curmod, modname)
-                            # replace obj with value retrieved
+                    varpath = iter(reduce_val.split('.'))
+                    # curmod will be transformed by the
+                    # loop into the value to pickle
+                    curmod = sys.modules[next(varpath)]
+                    for modname in varpath:
+                        curmod = getattr(curmod, modname)
+                        # replace obj with value retrieved
                         return self._flatten(curmod)
                 except KeyError:
                     # well, we can't do anything with that, so we ignore it
@@ -331,7 +334,9 @@ class Pickler(object):
                 f, args, state, listitems, dictitems = rv_as_list
 
                 # check that getstate/setstate is sane
-                if not (state and hasattr(obj, '__getstate__') and not hasattr(obj, '__setstate__') and not isinstance(obj, dict)):
+                if not (state and hasattr(obj, '__getstate__')
+                            and not hasattr(obj, '__setstate__')
+                            and not isinstance(obj, dict)):
                     # turn iterators to iterables for convenient serialization
                     if rv_as_list[3]:
                         rv_as_list[3] = tuple(rv_as_list[3])
@@ -349,7 +354,8 @@ class Pickler(object):
                 data[tags.OBJECT] = class_name
 
             if has_getnewargs_ex:
-                data[tags.NEWARGSEX] = list(map(self._flatten, obj.__getnewargs_ex__()))
+                data[tags.NEWARGSEX] = list(
+                    map(self._flatten, obj.__getnewargs_ex__()))
 
             if has_getnewargs and not has_getnewargs_ex:
                 data[tags.NEWARGS] = self._flatten(obj.__getnewargs__())

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import quopri
 import sys
-import gc
 
 from . import util
 from . import tags
@@ -78,7 +77,7 @@ class _IDProxy(_Proxy):
 
     def get(self):
         return self._objs[self._index]
-    
+
 
 def _obj_setattr(obj, attr, proxy):
     setattr(obj, attr, proxy.get())
@@ -110,7 +109,6 @@ class Unpickler(object):
         self._obj_to_idx = {}
         self._objs = []
         self._proxies = []
-        self._promises = {}
 
     def restore(self, obj, reset=True):
         """Restores a flattened object to its original python state.
@@ -136,7 +134,7 @@ class Unpickler(object):
         for (obj, attr, proxy, method) in self._proxies:
             method(obj, attr, proxy)
         self._proxies = []
-            
+
     def _restore(self, obj):
         if has_tag(obj, tags.B64):
             restore = self._restore_base64

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
-# Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com)
+# Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com) and contributors
 # All rights reserved.
 #
 # This software is licensed as described in the file COPYING, which
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import quopri
 import sys
+import gc
 
 from . import util
 from . import tags
@@ -70,6 +71,14 @@ class _Proxy(object):
     def reset(self, instance):
         self.instance = instance
 
+class _IDProxy(_Proxy):
+    def __init__(self, objs, index):
+        self._index = index
+        self._objs = objs
+
+    def get(self):
+        return self._objs[self._index]
+    
 
 def _obj_setattr(obj, attr, proxy):
     setattr(obj, attr, proxy.get())
@@ -101,6 +110,7 @@ class Unpickler(object):
         self._obj_to_idx = {}
         self._objs = []
         self._proxies = []
+        self._promises = {}
 
     def restore(self, obj, reset=True):
         """Restores a flattened object to its original python state.
@@ -126,7 +136,7 @@ class Unpickler(object):
         for (obj, attr, proxy, method) in self._proxies:
             method(obj, attr, proxy)
         self._proxies = []
-
+            
     def _restore(self, obj):
         if has_tag(obj, tags.B64):
             restore = self._restore_base64
@@ -176,13 +186,19 @@ class Unpickler(object):
         Assumes that iterator items (the last two) are represented as lists
         as per pickler implementation.
         """
+        proxy = _Proxy()
+        self._mkref(proxy)
         reduce_val = obj[tags.REDUCE]
-        f, args, state, listitems, dictitems = map(self._restore, reduce_val)
+        reduce_tuple = f, args, state, listitems, dictitems = map(self._restore, reduce_val)
 
         if f == tags.NEWOBJ or f.__name__ == '__newobj__':
             # mandated special case
             cls = args[0]
+            if not isinstance(cls, type):
+                cls = self._restore(cls)
+
             stage1 = cls.__new__(cls, *args[1:])
+
         else:
             stage1 = f(*args)
 
@@ -192,11 +208,25 @@ class Unpickler(object):
             except AttributeError:
                 # it's fine - we'll try the prescribed default methods
                 try:
-                    stage1.__dict__.update(state)
+                    # we can't do a straight update here because we
+                    # need object identity of the state dict to be
+                    # preserved so that _swap_proxies works out
+                    for k in stage1.__dict__.keys():
+                        if k not in state:
+                            state[k] = stage1.__dict__[k]
+                    stage1.__dict__ = state
                 except AttributeError:
                     # next prescribed default
-                    for k, v in state.items():
-                        setattr(stage1, k, v)
+                    try:
+                        for k, v in state.items():
+                            setattr(stage1, k, v)
+                    except:
+                        dict_state, slots_state = state
+                        if dict_state:
+                            stage1.__dict__.update(dict_state)
+                        if slots_state:
+                            for k, v in slots_state.items():
+                                setattr(stage1, k, v)
 
         if listitems:
             # should be lists if not None
@@ -210,11 +240,16 @@ class Unpickler(object):
             for k, v in dictitems:
                 stage1.__setitem__(k, v)
 
-        self._mkref(stage1)
+        proxy.reset(stage1)
+        self._swapref(proxy, stage1)
         return stage1
 
     def _restore_id(self, obj):
-        return self._objs[obj[tags.ID]]
+        try:
+            idx = obj[tags.ID]
+            return self._objs[idx]
+        except IndexError:
+            return _IDProxy(self._objs, idx)
 
     def _restore_ref(self, obj):
         return self._namedict.get(obj[tags.REF])
@@ -416,6 +451,10 @@ class Unpickler(object):
             self._namestack.append(str_k)
             k = restore_key(k)
             data[k] = self._restore(v)
+            # k is currently a proxy and must be replaced
+            if isinstance(data[k], _Proxy):
+                self._proxies.append((data, k, data[k], _obj_setvalue))
+
             self._namestack.pop()
         return data
 

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -368,6 +368,7 @@ def is_reducible(obj):
                 is_sequence_subclass(obj) or
                 is_function(obj) or
                 is_module(obj) or
+                is_iterator(obj) or
                 type(getattr(obj, '__slots__', None)) is IteratorType or
                 type(obj) is object or
                 obj is object or

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -407,7 +407,7 @@ def has_reduce(obj):
     # reduce
     if is_noncomplex(obj):
          return (False, True)
-    
+
     has_reduce = False
     has_reduce_ex = False
 
@@ -417,7 +417,7 @@ def has_reduce(obj):
     # For object instance
     has_reduce = in_dict(obj, REDUCE) or in_slots(obj, REDUCE)
     has_reduce_ex = in_dict(obj, REDUCE_EX) or in_slots(obj, REDUCE_EX) 
-    
+
     # turn to the MRO
     for base in type(obj).__mro__:
         if is_reducible(base):
@@ -441,7 +441,6 @@ def has_reduce(obj):
         if not has_reduce_ex_cls is object_reduce_ex:
              has_reduce_ex = has_reduce_ex_cls
 
-    
     return (has_reduce, has_reduce_ex)
 
 

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -366,7 +366,6 @@ def is_reducible(obj):
                 is_tuple(obj) or
                 is_dictionary_subclass(obj) or
                 is_sequence_subclass(obj) or
-                is_noncomplex(obj) or
                 is_function(obj) or
                 is_module(obj) or
                 type(getattr(obj, '__slots__', None)) is IteratorType or
@@ -403,6 +402,12 @@ def has_reduce(obj):
     if not is_reducible(obj) or is_type(obj):
         return (False, False)
 
+    # in this case, reduce works and is desired
+    # notwithstanding depending on default object
+    # reduce
+    if is_noncomplex(obj):
+         return (False, True)
+    
     has_reduce = False
     has_reduce_ex = False
 
@@ -410,17 +415,33 @@ def has_reduce(obj):
     REDUCE_EX = '__reduce_ex__'
 
     # For object instance
-    has_reduce = in_dict(obj, REDUCE) or in_slots(obj, REDUCE) or getattr(obj, REDUCE, False)
-    has_reduce_ex = in_dict(obj, REDUCE_EX) or in_slots(obj, REDUCE_EX) or getattr(obj, REDUCE_EX, False)
-
+    has_reduce = in_dict(obj, REDUCE) or in_slots(obj, REDUCE)
+    has_reduce_ex = in_dict(obj, REDUCE_EX) or in_slots(obj, REDUCE_EX) 
+    
     # turn to the MRO
     for base in type(obj).__mro__:
         if is_reducible(base):
             has_reduce = has_reduce or in_dict(base, REDUCE)
             has_reduce_ex = has_reduce_ex or in_dict(base, REDUCE_EX)
-        if has_reduce_ex and has_reduce_ex:
-            return (True, True)
+        if has_reduce and has_reduce_ex:
+            return (has_reduce, has_reduce_ex)
 
+    # for things that don't have a proper dict but can be getattred (rare, but includes some
+    # builtins)
+    cls = type(obj)
+    object_reduce = getattr(object, REDUCE)
+    object_reduce_ex = getattr(object, REDUCE_EX)
+    if not has_reduce:
+         has_reduce_cls = getattr(cls, REDUCE, False)
+         if not has_reduce_cls is object_reduce:
+             has_reduce = has_reduce_cls
+
+    if not has_reduce_ex:
+        has_reduce_ex_cls = getattr(cls, REDUCE_EX, False)
+        if not has_reduce_ex_cls is object_reduce_ex:
+             has_reduce_ex = has_reduce_ex_cls
+
+    
     return (has_reduce, has_reduce_ex)
 
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
-# Copyright (C) 2009, 2011, 2013 David Aguilar
+# Copyright (C) 2009, 2011, 2013 David Aguilar and contributors
 # All rights reserved.
 #
 # This software is licensed as described in the file COPYING, which
@@ -402,6 +402,7 @@ class JSONPickleTestCase(SkippableTest):
         expect = {'name': 'A name', 'child': None}
         pickle = jsonpickle.encode(self.obj, unpicklable=False)
         actual = jsonpickle.decode(pickle)
+        import pdb; pdb.set_trace()
         self.assertEqual(expect['name'], actual['name'])
 
     def test_decode(self):

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -402,7 +402,6 @@ class JSONPickleTestCase(SkippableTest):
         expect = {'name': 'A name', 'child': None}
         pickle = jsonpickle.encode(self.obj, unpicklable=False)
         actual = jsonpickle.decode(pickle)
-        import pdb; pdb.set_trace()
         self.assertEqual(expect['name'], actual['name'])
 
     def test_decode(self):

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -12,6 +12,7 @@ import jsonpickle
 from jsonpickle import handlers
 from jsonpickle import tags
 from jsonpickle.compat import queue, set, unicode, bytes, PY2, PY_MINOR
+import jsonpickle.util as util
 
 from helper import SkippableTest
 
@@ -428,11 +429,11 @@ class AdvancedObjectsTestCase(SkippableTest):
         self.assertEqual(newobj.c.name, 'c')
 
     def test_newstyleslots_iterable(self):
-        obj = ThingWithIterableSlots('a', 'b')
+        obj = ThingWithIterableSlots('alpha', 'bravo')
         jsonstr = jsonpickle.encode(obj)
         newobj = jsonpickle.decode(jsonstr)
-        self.assertEqual(newobj.a, 'a')
-        self.assertEqual(newobj.b, 'b')
+        self.assertEqual(newobj.a, 'alpha')
+        self.assertEqual(newobj.b, 'bravo')
 
     def test_newstyleslots_string_slot(self):
         obj = ThingWithStringSlots('a', 'b')
@@ -520,6 +521,22 @@ class AdvancedObjectsTestCase(SkippableTest):
         self.assertTrue('<BrokenReprThing "test">' in flattened)
         self.assertTrue(flattened['<BrokenReprThing "test">'])
 
+
+    def test_ordered_dict_reduces(self):
+        if sys.version_info < (2, 7):
+            return
+
+        d = collections.OrderedDict()
+        d.update(c=3)
+        d.update(a=1)
+        d.update(b=2)
+
+        has_reduce, has_reduce_ex = util.has_reduce(d)
+
+        self.assertTrue(util.is_reducible(d))
+        self.assertTrue(has_reduce or has_reduce_ex)
+
+        
     def test_ordered_dict(self):
         if sys.version_info < (2, 7):
             return
@@ -670,7 +687,6 @@ class AdvancedObjectsTestCase(SkippableTest):
         flat = self.pickler.flatten(obj)
         actual = flat[tags.STATE]
         self.assertEqual(expect, actual)
-
         restored = self.unpickler.restore(flat)
         self.assertEqual(expect, restored)
 


### PR DESCRIPTION
This PR eliminates simplereduce handler and its subclasses, and fixes the cases in the main code that those handlers were papering over. 

This also catches a few undocumented edgecases with reduce behaviour, and some under-explored cases, like proxies interacting with reduce.

@davvid 