### PR TITLE
make compatible with early versions of numpy

### DIFF
--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -136,7 +136,10 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
             data = super(NumpyNDArrayHandlerBinary, self).flatten(obj, data)
         else:
             # encode as binary
-            buffer = obj.tobytes(order='a')	 # numpy docstring is lacking as of 1.11.2, but this is the option we need
+            if hasattr(obj, 'tobytes'):
+                buffer = obj.tobytes(order='a') # numpy docstring is lacking as of 1.11.2, but this is the option we need
+            else:
+                buffer = obj.tostring(order='a') # numpy < 1.9 compatibility
             if self.compression:
                 buffer = self.compression.compress(buffer)
             data['values'] = b64encode(buffer)


### PR DESCRIPTION
`numpy.ndarray.tobytes` was introduced in numpy==1.9.0, in earlier version it was called `numpy.ndarray.tostring`. In the later versions `tostring` exists still as an alias for `tobytes` [1]. All numpy tests pass with numpy==1.8.0

[[1] numpy.ndarray.tostring](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.tostring.html)