### PR TITLE
Delint.

### DIFF
--- a/contrib/pyqt-reduce-handler.py
+++ b/contrib/pyqt-reduce-handler.py
@@ -11,15 +11,18 @@ from PyQt4 import QtCore
 import jsonpickle
 from jsonpickle import handlers
 
+text_type = eval('unicode') if str is bytes else str
+
 
 class QReduceHandler(handlers.BaseHandler):
 
     def flatten(self, obj, data):
         pickler = self.context
         if not pickler.unpicklable:
-            return unicode(obj)
+            return text_type(obj)
         flatten = pickler.flatten
-        data['__reduce__'] = [flatten(i, reset=False) for i in obj.__reduce__()[1]]
+        data['__reduce__'] = [
+            flatten(i, reset=False) for i in obj.__reduce__()[1]]
         return data
 
     def restore(self, data):
@@ -34,6 +37,7 @@ class QReduceHandler(handlers.BaseHandler):
         factory = getattr(module, classname)
 
         return factory(*args)
+
 
 handlers.register(QtCore.QPointF, QReduceHandler)
 

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -55,17 +55,16 @@ added to JSON::
 """
 from __future__ import absolute_import, division, unicode_literals
 
-from . import pickler
-from . import unpickler
-from .backend import JSONBackend
-from .version import __version__
+import importlib
+
 from .backend import json
-from .handlers import register  # side-effect: registers built-in handlers
-from .handlers import unregister
-from .pickler import Pickler, encode
-from .unpickler import Unpickler, decode
+from .pickler import encode
+from .unpickler import decode
 
 __all__ = ('encode', 'decode')
+
+# register built-in handlers
+importlib.import_module('.handlers', package=__name__)
 
 # Export specific JSONPluginMgr methods into the jsonpickle namespace
 set_preferred_backend = json.set_preferred_backend

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -74,6 +74,6 @@ load_backend = json.load_backend
 remove_backend = json.remove_backend
 enable_fallthrough = json.enable_fallthrough
 
-# json.load(),loads(), dump(), dumps() compatibility
+# json.load(), loads(), dump(), dumps() compatibility
 dumps = encode
 loads = decode

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -55,8 +55,6 @@ added to JSON::
 """
 from __future__ import absolute_import, division, unicode_literals
 
-import importlib
-
 from .backend import json
 from .pickler import encode
 from .unpickler import decode
@@ -72,7 +70,7 @@ from .unpickler import Unpickler  # noqa: F401
 __all__ = ('encode', 'decode')
 
 # register built-in handlers
-importlib.import_module('.handlers', package=__name__)
+__import__('jsonpickle.handlers', level=0)
 
 # Export specific JSONPluginMgr methods into the jsonpickle namespace
 set_preferred_backend = json.set_preferred_backend

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -61,6 +61,14 @@ from .backend import json
 from .pickler import encode
 from .unpickler import decode
 
+# Export other names not in __all__
+from .backend import JSONBackend  # noqa: F401
+from .version import __version__  # noqa: F401
+from .handlers import register  # noqa: F401
+from .handlers import unregister  # noqa: F401
+from .pickler import Pickler  # noqa: F401
+from .unpickler import Unpickler  # noqa: F401
+
 __all__ = ('encode', 'decode')
 
 # register built-in handlers

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -4,7 +4,8 @@ Custom handlers may be created to handle other objects. Each custom handler
 must derive from :class:`jsonpickle.handlers.BaseHandler` and
 implement ``flatten`` and ``restore``.
 
-A handler can be bound to other types by calling :func:`jsonpickle.handlers.register`.
+A handler can be bound to other types by calling
+:func:`jsonpickle.handlers.register`.
 
 :class:`jsonpickle.customhandlers.SimpleReduceHandler` is suitable for handling
 objects that implement the reduce protocol::
@@ -21,13 +22,9 @@ objects that implement the reduce protocol::
 
 """
 from __future__ import absolute_import, division, unicode_literals
-import collections
 import copy
 import datetime
-import decimal
 import re
-import sys
-import time
 import uuid
 
 from . import util
@@ -46,11 +43,14 @@ class Registry(object):
         :param cls_or_name: the type or its fully qualified name
         :param default: default value, if a matching handler is not found
 
-        Looks up a handler by type reference or its fully qualified name. If a direct match
-        is not found, the search is performed over all handlers registered with base=True.
+        Looks up a handler by type reference or its fully
+        qualified name. If a direct match
+        is not found, the search is performed over all
+        handlers registered with base=True.
         """
         handler = self._handlers.get(cls_or_name)
-        if handler is None and util.is_type(cls_or_name):  # attempt to find a base class
+        # attempt to find a base class
+        if handler is None and util.is_type(cls_or_name):
             for cls, base_handler in self._base_handlers.items():
                 if issubclass(cls_or_name, cls):
                     return base_handler
@@ -60,10 +60,13 @@ class Registry(object):
         """Register the a custom handler for a class
 
         :param cls: The custom object class to handle
-        :param handler: The custom handler class (if None, a decorator wrapper is returned)
-        :param base: Indicates whether the handler should be registered for all subclasses
+        :param handler: The custom handler class (if
+            None, a decorator wrapper is returned)
+        :param base: Indicates whether the handler should
+            be registered for all subclasses
 
-        This function can be also used as a decorator by omitting the `handler` argument::
+        This function can be also used as a decorator
+        by omitting the `handler` argument::
 
             @jsonpickle.handlers.register(Foo, base=True)
             class FooHandler(jsonpickle.handlers.BaseHandler):
@@ -79,7 +82,8 @@ class Registry(object):
             raise TypeError('{0!r} is not a class/type'.format(cls))
         # store both the name and the actual type for the ugly cases like
         # _sre.SRE_Pattern that cannot be loaded back directly
-        self._handlers[util.importable_name(cls)] = self._handlers[cls] = handler
+        self._handlers[util.importable_name(cls)] = \
+            self._handlers[cls] = handler
         if base:
             # only store the actual type for subclass checking
             self._base_handlers[cls] = handler
@@ -214,6 +218,7 @@ class QueueHandler(BaseHandler):
     def restore(self, data):
         return queue.Queue()
 
+
 QueueHandler.handles(queue.Queue)
 
 
@@ -228,7 +233,8 @@ class CloneFactory(object):
         return clone(self.exemplar)
 
     def __repr__(self):
-        return ('<CloneFactory object at 0x%x (%s)>' % (id(self), self.exemplar))
+        return (
+            '<CloneFactory object at 0x%x (%s)>' % (id(self), self.exemplar))
 
 
 class UUIDHandler(BaseHandler):
@@ -240,5 +246,6 @@ class UUIDHandler(BaseHandler):
 
     def restore(self, data):
         return uuid.UUID(data['hex'])
+
 
 UUIDHandler.handles(uuid.UUID)

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
-# Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com) and contributors
+# Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com)
+# and contributors
 # All rights reserved.
 #
 # This software is licensed as described in the file COPYING, which
@@ -10,12 +11,13 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import warnings
 import sys
+import types
 from itertools import chain, islice
 
 from . import util
 from . import tags
 from . import handlers
-from .backend import JSONBackend, json
+from .backend import json
 from .compat import numeric_types, unicode, PY3, PY2
 
 
@@ -206,7 +208,7 @@ class Pickler(object):
 
     def _get_flattener(self, obj):
 
-        if PY2 and isinstance(obj, file):
+        if PY2 and isinstance(obj, types.FileType):
             return self._flatten_file
 
         if util.is_primitive(obj):
@@ -267,14 +269,14 @@ class Pickler(object):
         """
         Special case file objects
         """
-        assert not PY3 and isinstance(obj, file)
+        assert not PY3 and isinstance(obj, types.FileType)
         return None
 
     def _flatten_bytestring(self, obj):
         if PY2:
             try:
                 return obj.decode('utf-8')
-            except:
+            except Exception:
                 pass
         return {tags.B64: base64.encodestring(obj).decode('utf-8')}
 
@@ -361,8 +363,8 @@ class Pickler(object):
 
                 # check that getstate/setstate is sane
                 if not (state and hasattr(obj, '__getstate__')
-                            and not hasattr(obj, '__setstate__')
-                            and not isinstance(obj, dict)):
+                        and not hasattr(obj, '__setstate__')
+                        and not isinstance(obj, dict)):
                     # turn iterators to iterables for convenient serialization
                     if rv_as_list[3]:
                         rv_as_list[3] = tuple(rv_as_list[3])
@@ -417,7 +419,8 @@ class Pickler(object):
 
         if util.is_iterator(obj):
             # force list in python 3
-            data[tags.ITERATOR] = list(map(self._flatten, islice(obj, self._max_iter)))
+            data[tags.ITERATOR] = list(
+                map(self._flatten, islice(obj, self._max_iter)))
             return data
 
         if has_dict:
@@ -528,7 +531,7 @@ class Pickler(object):
             elif not isinstance(k, (str, unicode)):
                 try:
                     k = repr(k)
-                except:
+                except Exception:
                     k = unicode(k)
 
         data[k] = self._flatten(v)

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -63,10 +63,14 @@ def has_method(obj, name):
     if not isinstance(func, (types.MethodType, types.FunctionType)):
         return False
 
-    # need to go through __dict__'s since in py3 methods are essentially descriptors
-    base_type = obj if is_type(obj) else obj.__class__  # __class__ for old-style classes
+    # need to go through __dict__'s since in py3
+    # methods are essentially descriptors
+
+    # __class__ for old-style classes
+    base_type = obj if is_type(obj) else obj.__class__
     original = None
-    for subtype in inspect.getmro(base_type):  # there is no .mro() for old-style classes
+    # there is no .mro() for old-style classes
+    for subtype in inspect.getmro(base_type):
         original = vars(subtype).get(name)
         if original is not None:
             break
@@ -342,22 +346,23 @@ def is_iterator(obj):
 def is_collections(obj):
     try:
         return type(obj).__module__ == 'collections'
-    except:
+    except Exception:
         return False
 
 
 IteratorType = type(iter(''))
 
+
 def is_reducible(obj):
     """
-    Returns false if of a type which have special casing, and should not have their
-    __reduce__ methods used
+    Returns false if of a type which have special casing,
+    and should not have their __reduce__ methods used
     """
     # defaultdicts may contain functions which we cannot serialise
     if is_collections(obj) and not isinstance(obj, collections.defaultdict):
         return True
     return (not
-                (is_list(obj) or
+            (is_list(obj) or
                 is_list_like(obj) or
                 is_primitive(obj) or
                 is_bytes(obj) or
@@ -375,7 +380,7 @@ def is_reducible(obj):
                 type(obj) is object or
                 obj is object or
                 (is_type(obj) and obj.__module__ == 'datetime')
-                ))
+             ))
 
 
 def in_dict(obj, key, default=False):
@@ -391,7 +396,9 @@ def in_slots(obj, key, default=False):
     Returns true if key exists in obj.__slots__; false if not in.
     If obj.__slots__ is absent, return default
     """
-    return (key in obj.__slots__) if getattr(obj, '__slots__', None) else default
+    return (
+        (key in obj.__slots__) if getattr(obj, '__slots__', None) else default
+    )
 
 
 def has_reduce(obj):
@@ -409,7 +416,7 @@ def has_reduce(obj):
     # notwithstanding depending on default object
     # reduce
     if is_noncomplex(obj):
-         return (False, True)
+        return (False, True)
 
     has_reduce = False
     has_reduce_ex = False
@@ -419,7 +426,7 @@ def has_reduce(obj):
 
     # For object instance
     has_reduce = in_dict(obj, REDUCE) or in_slots(obj, REDUCE)
-    has_reduce_ex = in_dict(obj, REDUCE_EX) or in_slots(obj, REDUCE_EX) 
+    has_reduce_ex = in_dict(obj, REDUCE_EX) or in_slots(obj, REDUCE_EX)
 
     # turn to the MRO
     for base in type(obj).__mro__:
@@ -429,20 +436,20 @@ def has_reduce(obj):
         if has_reduce and has_reduce_ex:
             return (has_reduce, has_reduce_ex)
 
-    # for things that don't have a proper dict but can be getattred (rare, but includes some
-    # builtins)
+    # for things that don't have a proper dict but can be
+    # getattred (rare, but includes some builtins)
     cls = type(obj)
     object_reduce = getattr(object, REDUCE)
     object_reduce_ex = getattr(object, REDUCE_EX)
     if not has_reduce:
-         has_reduce_cls = getattr(cls, REDUCE, False)
-         if not has_reduce_cls is object_reduce:
-             has_reduce = has_reduce_cls
+        has_reduce_cls = getattr(cls, REDUCE, False)
+        if has_reduce_cls is not object_reduce:
+            has_reduce = has_reduce_cls
 
     if not has_reduce_ex:
         has_reduce_ex_cls = getattr(cls, REDUCE_EX, False)
-        if not has_reduce_ex_cls is object_reduce_ex:
-             has_reduce_ex = has_reduce_ex_cls
+        if has_reduce_ex_cls is not object_reduce_ex:
+            has_reduce_ex = has_reduce_ex_cls
 
     return (has_reduce, has_reduce_ex)
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,10 @@ exec(open(version).read(), scope)
 SETUP_ARGS = dict(
     name='jsonpickle',
     version=scope['__version__'],
-    description='Python library for serializing any arbitrary object graph into JSON',
-    long_description='jsonpickle converts complex Python objects to and from JSON.',
+    description=(
+        'Python library for serializing any arbitrary object graph into JSON'),
+    long_description=(
+        'jsonpickle converts complex Python objects to and from JSON.'),
     author='David Aguilar',
     author_email='davvid@gmail.com',
     url='http://jsonpickle.github.io/',

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -138,7 +138,7 @@ class JsonlibTestCase(BackendBase):
             return self.skip('no jsonlib for python3')
         expected_pickled = (
             '{"things":[{'
-            '"py\/object":"backend_test.Thing",'
+            r'"py\/object":"backend_test.Thing",'
             '"name":"data","child":null}'
             ']}')
         self.assertEncodeDecode(expected_pickled)
@@ -165,7 +165,7 @@ class UJsonTestCase(BackendBase):
     def test_backend(self):
         expected_pickled = (
             '{"things":[{'
-            '"py\/object":"backend_test.Thing",'
+            r'"py\/object":"backend_test.Thing",'
             '"name":"data","child":null}'
             ']}')
         self.assertEncodeDecode(expected_pickled)

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -32,6 +32,6 @@ if doc['feed']['title'] != unpickled['feed']['title']:
     print 'Not a match'
 """ % mod
 
-print 'Using %s' % mod
+print('Using %s' % mod)
 json_test = timeit.Timer(stmt=json)
-print "%.9f sec/pass " % (json_test.timeit(number=number) / number)
+print("%.9f sec/pass " % (json_test.timeit(number=number) / number))

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -34,6 +34,7 @@ class UTC(datetime.tzinfo):
     def dst(self, dt):
         return datetime.timedelta()
 
+
 utc = UTC()
 
 
@@ -258,6 +259,7 @@ def suite():
     suite.addTest(unittest.makeSuite(DateTimeAdvancedTestCase))
     suite.addTest(unittest.makeSuite(DateTimeInnerReferenceTestCase))
     return suite
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -99,5 +99,6 @@ def suite():
     suite.addTest(unittest.makeSuite(DocumentTestCase))
     return suite
 
+
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -132,10 +132,10 @@ class HandlerTestCase(unittest.TestCase):
 
     def test_custom_handler_can_rewrite_everything(self):
         """Test the low-level pickling structures"""
-        jsonpickle.unregister(CustomObject)
-        jsonpickle.register(CustomObject, SithHandler)
+        jsonpickle.handlers.unregister(CustomObject)
+        jsonpickle.handlers.register(CustomObject, SithHandler)
         obj = CustomObject('jarjar')  # secret sith lord jarjar
-        pickler = jsonpickle.Pickler()
+        pickler = jsonpickle.pickler.Pickler()
         data = pickler.flatten(obj)
         self.assertTrue(isinstance(data, dict))
         self.assertEqual(len(data), 2)

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -54,7 +54,6 @@ class DecoratedHandler(NullHandler):
     pass
 
 
-
 class SithHandler(jsonpickle.handlers.BaseHandler):
     """(evil) serialization handler that rewrites the entire object"""
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1375,5 +1375,6 @@ def suite():
     suite.addTest(doctest.DocTestSuite(jsonpickle.unpickler))
     return suite
 
+
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -399,6 +399,22 @@ class JSONPickleTestCase(SkippableTest):
             % tags.OBJECT
         )
 
+    def test_API_names(self):
+        """
+        Enforce expected names in main module
+        """
+        names = list(vars(jsonpickle))
+        self.assertIn('pickler', names)
+        self.assertIn('unpickler', names)
+        self.assertIn('JSONBackend', names)
+        self.assertIn('__version__', names)
+        self.assertIn('register', names)
+        self.assertIn('unregister', names)
+        self.assertIn('Pickler', names)
+        self.assertIn('Unpickler', names)
+        self.assertIn('encode', names)
+        self.assertIn('decode', names)
+
     def test_encode(self):
         expect = self.obj
         pickle = jsonpickle.encode(self.obj)

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -113,7 +113,8 @@ class NumpyTestCase(SkippableTest):
 
         if not PY2:
             arrays.extend([
-                np.rec.array([('NGC1001', 11), ('NGC1002', 1.), ('NGC1003', 1.)],
+                np.rec.array([
+                    ('NGC1001', 11), ('NGC1002', 1.), ('NGC1003', 1.)],
                              dtype=[('target', 'S20'), ('V_mag', 'f4')])
             ])
         for array in arrays:

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -744,7 +744,9 @@ class AdvancedObjectsTestCase(SkippableTest):
 
         restore = self.unpickler.restore
         flatten = self.pickler.flatten
-        roundtrip = lambda obj: restore(flatten(obj))
+
+        def roundtrip(obj):
+            return restore(flatten(obj))
         self.assertTrue(roundtrip(IntEnumTest.X) is IntEnumTest.X)
         self.assertTrue(roundtrip(IntEnumTest) is IntEnumTest)
 
@@ -792,7 +794,7 @@ class AdvancedObjectsTestCase(SkippableTest):
             self.assertEqual(type(encoded), unicode)
         else:
             self.assertNotEqual(encoded, u1)
-            b64ustr= base64.encodestring(b'foo').decode('utf-8')
+            b64ustr = base64.encodestring(b'foo').decode('utf-8')
             self.assertEqual({tags.B64: b64ustr}, encoded)
             self.assertEqual(type(encoded[tags.B64]), unicode)
         decoded = self.unpickler.restore(encoded)
@@ -805,7 +807,7 @@ class AdvancedObjectsTestCase(SkippableTest):
         # bytestrings that we can't decode to UTF-8 will always be wrapped
         encoded = self.pickler.flatten(b2)
         self.assertNotEqual(encoded, b2)
-        b64ustr= base64.encodestring(b'foo\xff').decode('utf-8')
+        b64ustr = base64.encodestring(b'foo\xff').decode('utf-8')
         self.assertEqual({tags.B64: b64ustr}, encoded)
         self.assertEqual(type(encoded[tags.B64]), unicode)
         decoded = self.unpickler.restore(encoded)
@@ -854,6 +856,7 @@ class UnicodeMixinHandler(handlers.BaseHandler):
 
     def restore(self, obj):
         return UnicodeMixin(obj['value'])
+
 
 handlers.register(UnicodeMixin, UnicodeMixinHandler)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -10,8 +10,8 @@
 import os
 import sys
 
-testdir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(1, os.path.dirname(testdir))
+testdir = os.path.dirname(os.path.abspath(__file__))  # noqa: E402
+sys.path.insert(1, os.path.dirname(testdir))  # noqa: E402
 
 import unittest
 

--- a/tests/sqlalchemy_test.py
+++ b/tests/sqlalchemy_test.py
@@ -94,9 +94,10 @@ class SQLAlchemyTestCase(SkippableTest):
             return self.skip('sqlalchemy is not installed')
 
         meta = sqa.MetaData()
-        expect = sqa.Table('test', meta,
-                sqa.Column('id', sqa.Integer()),
-                sqa.Column('text', sqa.Text()))
+        expect = sqa.Table(
+            'test', meta,
+            sqa.Column('id', sqa.Integer()),
+            sqa.Column('text', sqa.Text()))
 
         jsonstr = jsonpickle.dumps(expect)
         actual = jsonpickle.loads(jsonstr)
@@ -115,6 +116,7 @@ class SQLAlchemyTestCase(SkippableTest):
         self.assertEqual(expect.c.text.name, actual.c.text.name)
         self.assertEqual(expect.c.text.type.__class__,
                          actual.c.text.type.__class__)
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -238,5 +238,6 @@ def suite():
     suite.addTest(doctest.DocTestSuite(jsonpickle.util))
     return suite
 
+
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')


### PR DESCRIPTION
Fixes #201.

Most of the changes in this PR will have no effect on the functionality but only avoid linter warnings (as configured in setup.cfg).

The one main point of concern might be the names removed in `jsonpickle` (the top-level module). Given that these names were not declared in `__all__`, I suspect it's safe to remove them, although it's not improbable that some packages will be depending on these aliases. Probably a backward-incompatible release should be made as a result. Any other ideas on removing this apparent cruft?