### PR TITLE
Support builtin functions and nested classes

### DIFF
--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -110,7 +110,8 @@ def is_object(obj):
     False
     """
     return (isinstance(obj, object) and
-            not isinstance(obj, (type, types.FunctionType)))
+            not isinstance(obj, (type, types.FunctionType,
+                                 types.BuiltinFunctionType)))
 
 
 def is_primitive(obj):
@@ -277,7 +278,7 @@ def is_module_function(obj):
     """
 
     return (hasattr(obj, '__class__') and
-            isinstance(obj, types.FunctionType) and
+            isinstance(obj, (types.FunctionType, types.BuiltinFunctionType)) and
             hasattr(obj, '__module__') and
             hasattr(obj, '__name__') and
             obj.__name__ != '<lambda>')

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -507,7 +507,8 @@ def importable_name(cls):
     True
 
     """
-    name = cls.__name__
+    # Use the fully-qualified name if available (Python >= 3.3)
+    name = getattr(cls, '__qualname__', cls.__name__)
     module = translate_module_name(cls.__module__)
     return '%s.%s' % (module, name)
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -395,6 +395,13 @@ class PicklingTestCase(unittest.TestCase):
         self.assertEqual(expect, actual)
         self.assertTrue(expect is actual)
 
+    def test_builtin_function(self):
+        expect = dir
+        json = jsonpickle.encode(expect)
+        actual = jsonpickle.decode(json)
+        self.assertEqual(expect, actual)
+        self.assertTrue(expect is actual)
+
 
 class JSONPickleTestCase(SkippableTest):
 


### PR DESCRIPTION
As discussed in #192, this PR adds support for nested class definitions (for Python >=3.3) and for builtin functions such as `dir`. It fixes several examples mentioned in that issue, but I am not sure whether it does actually help for the problem with `KNeighborsClassifier` that the OP had.

Closes #176 (which I did not actually see before working on this). Although I'm not sure whether you want to consider it closed given that it only works with Python >= 3.3.