### PR TITLE
Always flatten primitives

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -191,7 +191,7 @@ class Pickler(object):
         self._seen.append(obj)
         max_reached = self._depth == self._max_depth
 
-        if max_reached or (not self.make_refs and id(obj) in self._objs):
+        if (max_reached or (not self.make_refs and id(obj) in self._objs)) and not util.is_primitive(obj):
             # break the cycle
             flatten_func = repr
         else:


### PR DESCRIPTION
There is no cycle to break for a primitive, so it seems more effective to return the flattened primitive. This resolves the issue where a unicode object would be repr()'d into a string with the u quote designation. 

resolves #198