### PR TITLE
Corrected usage of deprecated base64 methods

### DIFF
--- a/jsonpickle/compat.py
+++ b/jsonpickle/compat.py
@@ -10,8 +10,11 @@ if PY3:
     string_types = (str,)
     numeric_types = (int, float)
     ustr = str
+    from base64 import encodebytes, decodebytes
 else:
     import Queue as queue
     string_types = (basestring,)
     numeric_types = (int, float, long)
     ustr = unicode
+    from base64 import encodestring as encodebytes
+    from base64 import decodestring as decodebytes

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -16,7 +16,7 @@ from . import util
 from . import tags
 from . import handlers
 from .backend import json
-from .compat import numeric_types, string_types, PY3, PY2
+from .compat import numeric_types, string_types, PY3, PY2, encodebytes
 
 
 def encode(value,
@@ -276,7 +276,7 @@ class Pickler(object):
                 return obj.decode('utf-8')
             except Exception:
                 pass
-        return {tags.B64: base64.encodebytes(obj).decode('utf-8')}
+        return {tags.B64: encodebytes(obj).decode('utf-8')}
 
     def _flatten_obj_instance(self, obj):
         """Recursively flatten an instance and return a json-friendly dict

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -276,7 +276,7 @@ class Pickler(object):
                 return obj.decode('utf-8')
             except Exception:
                 pass
-        return {tags.B64: base64.encodestring(obj).decode('utf-8')}
+        return {tags.B64: base64.encodebytes(obj).decode('utf-8')}
 
     def _flatten_obj_instance(self, obj):
         """Recursively flatten an instance and return a json-friendly dict

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -12,7 +12,7 @@ import sys
 from . import util
 from . import tags
 from . import handlers
-from .compat import numeric_types
+from .compat import numeric_types, decodebytes
 from .backend import json
 
 
@@ -201,7 +201,7 @@ class Unpickler(object):
         return restore(obj)
 
     def _restore_base64(self, obj):
-        return base64.decodebytes(obj[tags.B64].encode('utf-8'))
+        return decodebytes(obj[tags.B64].encode('utf-8'))
 
     #: For backwards compatibility with bytes data produced by older versions
     def _restore_quopri(self, obj):

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -201,7 +201,7 @@ class Unpickler(object):
         return restore(obj)
 
     def _restore_base64(self, obj):
-        return base64.decodestring(obj[tags.B64].encode('utf-8'))
+        return base64.decodebytes(obj[tags.B64].encode('utf-8'))
 
     #: For backwards compatibility with bytes data produced by older versions
     def _restore_quopri(self, obj):

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -822,7 +822,7 @@ class AdvancedObjectsTestCase(SkippableTest):
             self.assertTrue(isinstance(encoded, compat.ustr))
         else:
             self.assertNotEqual(encoded, u1)
-            b64ustr = base64.encodestring(b'foo').decode('utf-8')
+            b64ustr = base64.encodebytes(b'foo').decode('utf-8')
             self.assertEqual({tags.B64: b64ustr}, encoded)
             self.assertTrue(isinstance(encoded[tags.B64], compat.ustr))
         decoded = self.unpickler.restore(encoded)
@@ -835,7 +835,7 @@ class AdvancedObjectsTestCase(SkippableTest):
         # bytestrings that we can't decode to UTF-8 will always be wrapped
         encoded = self.pickler.flatten(b2)
         self.assertNotEqual(encoded, b2)
-        b64ustr = base64.encodestring(b'foo\xff').decode('utf-8')
+        b64ustr = base64.encodebytes(b'foo\xff').decode('utf-8')
         self.assertEqual({tags.B64: b64ustr}, encoded)
         self.assertTrue(isinstance(encoded[tags.B64], compat.ustr))
         decoded = self.unpickler.restore(encoded)

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -12,7 +12,7 @@ from jsonpickle import compat
 from jsonpickle import handlers
 from jsonpickle import tags
 from jsonpickle import util
-from jsonpickle.compat import queue, PY2
+from jsonpickle.compat import queue, PY2, encodebytes
 
 from helper import SkippableTest
 
@@ -822,7 +822,7 @@ class AdvancedObjectsTestCase(SkippableTest):
             self.assertTrue(isinstance(encoded, compat.ustr))
         else:
             self.assertNotEqual(encoded, u1)
-            b64ustr = base64.encodebytes(b'foo').decode('utf-8')
+            b64ustr = encodebytes(b'foo').decode('utf-8')
             self.assertEqual({tags.B64: b64ustr}, encoded)
             self.assertTrue(isinstance(encoded[tags.B64], compat.ustr))
         decoded = self.unpickler.restore(encoded)
@@ -835,7 +835,7 @@ class AdvancedObjectsTestCase(SkippableTest):
         # bytestrings that we can't decode to UTF-8 will always be wrapped
         encoded = self.pickler.flatten(b2)
         self.assertNotEqual(encoded, b2)
-        b64ustr = base64.encodebytes(b'foo\xff').decode('utf-8')
+        b64ustr = encodebytes(b'foo\xff').decode('utf-8')
         self.assertEqual({tags.B64: b64ustr}, encoded)
         self.assertTrue(isinstance(encoded[tags.B64], compat.ustr))
         decoded = self.unpickler.restore(encoded)


### PR DESCRIPTION
See https://docs.python.org/3.5/library/base64.html#base64.encodestring and https://docs.python.org/3.5/library/base64.html#base64.decodestring