### PR TITLE
Allow iterators to be reduced and encoded

### DIFF
--- a/jsonpickle/compat.py
+++ b/jsonpickle/compat.py
@@ -18,3 +18,9 @@ else:
     ustr = unicode
     from base64 import encodestring as encodebytes
     from base64 import decodestring as decodebytes
+
+
+def iterator(class_):
+    if PY2 and hasattr(class_, '__next__'):
+        class_.next = class_.__next__
+    return class_

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -372,7 +372,6 @@ def is_reducible(obj):
                 is_sequence_subclass(obj) or
                 is_function(obj) or
                 is_module(obj) or
-                is_iterator(obj) or
                 type(getattr(obj, '__slots__', None)) is IteratorType or
                 type(obj) is object or
                 obj is object or

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -937,6 +937,18 @@ class PickleProtocol2ReduceTuple(object):
                 )
 
 
+@compat.iterator
+class ReducibleIterator(object):
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration()
+
+    def __reduce__(self):
+        return ReducibleIterator, ()
+
+
 def protocol_2_reduce_tuple_func(*args):
     return PickleProtocol2ReduceTupleFunc(*args)
 
@@ -1266,6 +1278,17 @@ class PicklingProtocol2TestCase(SkippableTest):
         self.assertEqual(next(decoded), '1')
         self.assertEqual(next(decoded), '2')
         self.assertEqual(next(decoded), '3')
+
+    def test_reduce_iterable(self):
+        """
+        An reducible object should be pickleable even if
+        it is also iterable.
+        """
+        instance = ReducibleIterator()
+        self.assertTrue(util.is_iterator(instance))
+        encoded = jsonpickle.encode(instance)
+        decoded = jsonpickle.decode(encoded)
+        self.assertIsInstance(decoded, ReducibleIterator)
 
     def test_reduce_string(self):
         """


### PR DESCRIPTION
In #216, we see a practical case where at iterator should be reducible.

This PR adds a test for this need and removes the code that prevents it from working as expected. No tests seem to be relying on the other expectation, so this seems like this behavior aligns better with what stdlib pickle does.