### PR TITLE
Unconditionally encode/decode base64 strings to/from text (unicode).

### DIFF
--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -508,16 +508,17 @@ def importable_name(cls):
 
 
 def b64encode(data):
-    payload = base64.b64encode(data)
-    if PY3 and is_bytes(payload):
-        payload = payload.decode('ascii')
-    return payload
+    """
+    Encode binary data to ascii text in base64. Data must be bytes.
+    """
+    return base64.b64encode(data).decode('ascii')
 
 
 def b64decode(payload):
-    if PY3 and not is_bytes(payload):
-        payload = bytes(payload, 'ascii')
-    return base64.b64decode(payload)
+    """
+    Decode payload - must be ascii text.
+    """
+    return base64.b64decode(payload.encode('ascii'))
 
 
 def itemgetter(obj, getter=operator.itemgetter(0)):


### PR DESCRIPTION
This change simplifies the b64encode/decode functions by unconditionally decoding to text in b64encode and unconditionally encoding to bytes in b64decode. This approach works on Python 2 also, because even if payload is str or bytes on Python 2, in `b64decode`, it will be decoded to text, then encoded to ascii.

This does change the behavior slightly, but I believe in a compatible way (and if tests are adequately covering the functions, they do pass).