### PR TITLE
Refactor and reindent to avoid linter warnings/errors.

### DIFF
--- a/jsonpickle/compat.py
+++ b/jsonpickle/compat.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 import sys
+import base64
 
 PY_MAJOR = sys.version_info[0]
 PY2 = PY_MAJOR == 2
@@ -7,17 +8,19 @@ PY3 = PY_MAJOR == 3
 
 if PY3:
     import queue
+    import builtins
     string_types = (str,)
     numeric_types = (int, float)
     ustr = str
     from base64 import encodebytes, decodebytes
 else:
-    import Queue as queue
-    string_types = (basestring,)
-    numeric_types = (int, float, long)
-    ustr = unicode
-    from base64 import encodestring as encodebytes
-    from base64 import decodestring as decodebytes
+    queue = __import__('Queue')
+    builtins = __import__('__builtin__')
+    string_types = (builtins.basestring,)
+    numeric_types = (int, float, builtins.long)
+    ustr = builtins.unicode
+    encodebytes = base64.encodestring
+    decodebytes = base64.decodestring
 
 
 def iterator(class_):

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -219,7 +219,8 @@ class CloneFactory(object):
 
     def __repr__(self):
         return (
-            '<CloneFactory object at 0x{:x} ({})>'.format(id(self), self.exemplar))
+            '<CloneFactory object at 0x{:x} ({})>'
+            .format(id(self), self.exemplar))
 
 
 class UUIDHandler(BaseHandler):

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -5,7 +5,6 @@
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution.
 from __future__ import absolute_import, division, unicode_literals
-import base64
 import warnings
 import sys
 import types
@@ -189,7 +188,12 @@ class Pickler(object):
         self._seen.append(obj)
         max_reached = self._depth == self._max_depth
 
-        if (max_reached or (not self.make_refs and id(obj) in self._objs)) and not util.is_primitive(obj):
+        in_cycle = (
+            max_reached or (
+                not self.make_refs
+                and id(obj) in self._objs
+            )) and not util.is_primitive(obj)
+        if in_cycle:
             # break the cycle
             flatten_func = repr
         else:
@@ -402,8 +406,7 @@ class Pickler(object):
 
         if util.is_module(obj):
             if self.unpicklable:
-                data[tags.REPR] = '{}/{}'.format(obj.__name__,
-                                             obj.__name__)
+                data[tags.REPR] = '{name}/{name}'.format(name=obj.__name__)
             else:
                 data = compat.ustr(obj)
             return data

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -5,7 +5,6 @@
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution.
 from __future__ import absolute_import, division, unicode_literals
-import base64
 import quopri
 import sys
 

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -19,7 +19,7 @@ import inspect
 
 from . import tags
 from . import compat
-from .compat import numeric_types, string_types, PY2, PY3
+from .compat import numeric_types, PY2, PY3
 
 if PY2:
     import __builtin__
@@ -212,9 +212,11 @@ def is_sequence_subclass(obj):
     True
     """
     return (hasattr(obj, '__class__')
-            and (issubclass(obj.__class__, SEQUENCES)
-                or is_list_like(obj))
-                and not is_sequence(obj))
+            and (
+                issubclass(obj.__class__, SEQUENCES)
+                or is_list_like(obj)
+            )
+            and not is_sequence(obj))
 
 
 def is_noncomplex(obj):


### PR DESCRIPTION
This commit fixes these linter errors:

```
jsonpickle/unpickler.py:8:1: F401 'base64' imported but unused
jsonpickle/compat.py:15:5: F401 'Queue as queue' imported but unused
jsonpickle/compat.py:16:21: F821 undefined name 'basestring'
jsonpickle/compat.py:17:34: F821 undefined name 'long'
jsonpickle/compat.py:18:12: F821 undefined name 'unicode'
jsonpickle/compat.py:19:5: F401 'base64.encodestring as encodebytes' imported but unused
jsonpickle/compat.py:20:5: F401 'base64.decodestring as decodebytes' imported but unused
jsonpickle/util.py:22:1: F401 '.compat.string_types' imported but unused
jsonpickle/util.py:216:17: E128 continuation line under-indented for visual indent
jsonpickle/util.py:217:17: E127 continuation line over-indented for visual indent
jsonpickle/handlers.py:222:81: E501 line too long (83 > 80 characters)
jsonpickle/pickler.py:8:1: F401 'base64' imported but unused
jsonpickle/pickler.py:192:81: E501 line too long (106 > 80 characters)
jsonpickle/pickler.py:406:46: E128 continuation line under-indented for visual indent
```