### PR TITLE
Use setdefault to set default values on a dict

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -239,8 +239,7 @@ class Unpickler(object):
                     # need object identity of the state dict to be
                     # preserved so that _swap_proxies works out
                     for k in stage1.__dict__.keys():
-                        if k not in state:
-                            state[k] = stage1.__dict__[k]
+                        state.setdefault(k, stage1.__dict__[k])
                     stage1.__dict__ = state
                 except AttributeError:
                     # next prescribed default

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -238,8 +238,8 @@ class Unpickler(object):
                     # we can't do a straight update here because we
                     # need object identity of the state dict to be
                     # preserved so that _swap_proxies works out
-                    for k in stage1.__dict__.keys():
-                        state.setdefault(k, stage1.__dict__[k])
+                    for k, v in stage1.__dict__.items():
+                        state.setdefault(k, v)
                     stage1.__dict__ = state
                 except AttributeError:
                     # next prescribed default

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -81,16 +81,10 @@ class PersistantVariables(object):
         self._data = {}
 
     def __getitem__(self, key):
-        if key not in self._data:
-            self._data[key] = TimestampedVariable(None)
-
-        return self._data[key]
+        return self._data.setdefault(key, TimestampedVariable(None))
 
     def __setitem__(self, key, value):
-        if key not in self._data:
-            self._data[key] = TimestampedVariable(value)
-
-        return self._data[key]
+        return self._data.setdefault(key, TimestampedVariable(value))
 
     def __repr__(self):
         return str(self._data)


### PR DESCRIPTION
This minor edit leverages `dict.setdefault` to more succinctly set unset values. I note that the behavior isn't identical. In particular, in datetime_test, the TimestampedVariable objects will get constructed and discarded. In my estimation, the costs and side-effects of these unneeded constructions should be negligible.