### PR TITLE
Prefer 'builtins' module name

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -572,7 +572,7 @@ class Pickler(object):
 def _mktyperef(obj):
     """Return a typeref dictionary
 
-    >>> _mktyperef(AssertionError) == {'py/type': '__builtin__.AssertionError'}
+    >>> _mktyperef(AssertionError) == {'py/type': 'builtins.AssertionError'}
     True
 
     """

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -591,7 +591,7 @@ def loadclass(module_and_name, classes=None):
 
     >>> loadclass('does.not.exist')
 
-    >>> loadclass('__builtin__.int')()
+    >>> loadclass('builtins.int')()
     0
 
     """

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -243,21 +243,14 @@ def is_function(obj):
     >>> is_function(1)
     False
     """
-    if type(obj) in (types.FunctionType,
-                     types.MethodType,
-                     types.LambdaType,
-                     types.BuiltinFunctionType,
-                     types.BuiltinMethodType):
-        return True
-    if not hasattr(obj, '__class__'):
-        return False
-    module = translate_module_name(obj.__class__.__module__)
-    name = obj.__class__.__name__
-    return (module == '__builtin__' and
-            name in ('function',
-                     'builtin_function_or_method',
-                     'instancemethod',
-                     'method-wrapper'))
+    function_types = (
+        types.FunctionType,
+        types.MethodType,
+        types.LambdaType,
+        types.BuiltinFunctionType,
+        types.BuiltinMethodType,
+    )
+    return type(obj) in function_types
 
 
 def is_module_function(obj):

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -321,7 +321,7 @@ class PicklingTestCase(unittest.TestCase):
 
         flattened = self.pickler.flatten(obj)
         self.assertEqual(flattened['typeref'],
-                         {tags.TYPE: '__builtin__.object'})
+                         {tags.TYPE: 'builtins.object'})
 
         inflated = self.unpickler.restore(flattened)
         self.assertEqual(inflated.typeref, object)
@@ -397,6 +397,19 @@ class PicklingTestCase(unittest.TestCase):
         actual = jsonpickle.decode(json)
         self.assertEqual(expect, actual)
         self.assertTrue(expect is actual)
+
+    def test_restore_legacy_builtins(self):
+        """
+        jsonpickle 0.9.6 and earlier used the Python 2 `__builtin__`
+        naming for builtins. Ensure those can be loaded until they're
+        no longer supported.
+        """
+        ae = jsonpickle.decode('{"py/type": "__builtin__.AssertionError"}')
+        assert ae is AssertionError
+        ae = jsonpickle.decode('{"py/type": "exceptions.AssertionError"}')
+        assert ae is AssertionError
+        cls = jsonpickle.decode('{"py/type": "__builtin__.int"}')
+        assert cls is int
 
 
 class JSONPickleTestCase(SkippableTest):


### PR DESCRIPTION
As laid out in #224, futurize the code to prefer the more modern naming.

I'd particularly like scrutiny on 8383649 as it removes what appears to be unused code. The tests continue to pass with that removal, but I worry there's untested behavior relying on that removed code. Can you think of any example that would be affected by that change?