### PR TITLE
Add pandas support, fix numpy bugs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@ Bug reports and merge requests are encouraged at the
 
 jsonpickle supports Python 2.7 and Python 3.4 or greater.
 
+Why jsonpickle?
+===============
+Data serialized with python's pickle (or cPickle or dill) is not easily readable outside of python. Using the json format, jsonpickle allows simple data types to be stored in a human-readable format, and more complex data types such as numpy arrays and pandas dataframes, to be machine-readable on any platform that supports json. E.g., unlike pickled data, jsonpickled data stored in an Amazon S3 bucket is indexible by Amazon's Athena.
 
 Install
 =======
@@ -45,6 +48,15 @@ enable the numpy extension by registering its handlers::
 
     >>> import jsonpickle.ext.numpy as jsonpickle_numpy
     >>> jsonpickle_numpy.register_handlers()
+
+Pandas Support
+=============
+jsonpickle includes a built-in pandas extension.  If would like to encode
+pandas DataFrame or Series objects then you must enable the pandas extension
+by registering its handlers::
+
+    >>> import jsonpickle.ext.pandas as jsonpickle_pandas
+    >>> jsonpickle_pandas.register_handlers()
 
 jsonpickleJS
 ============

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -1,0 +1,114 @@
+from __future__ import absolute_import
+
+import pandas as pd
+from io import StringIO
+import zlib
+
+from ..handlers import BaseHandler, register, unregister
+from ..util import b64decode, b64encode
+from ..backend import json
+
+__all__ = ['register_handlers', 'unregister_handlers']
+
+class PandasProcessor():
+
+    def __init__(self, size_threshold=500, compression=zlib):
+        """
+        :param size_threshold: nonnegative int or None
+            valid values for 'size_threshold' are all nonnegative
+            integers and None
+            if size_threshold is None, dataframes are always stored as csv strings
+        :param compression: a compression module or None
+            valid values for 'compression' are {zlib, bz2, None}
+            if compresion is None, no compression is applied
+        """
+        self.size_threshold = size_threshold
+        self.compression = compression
+
+    def flatten_pandas(self, buf, data, meta=None):
+        if self.size_threshold is not None and len(buf) > self.size_threshold:
+            if self.compression:
+                buf = self.compression.compress(buf.encode())
+                data['comp'] = True
+            data['values'] = b64encode(buf)
+            data['txt'] = False
+        else:
+            data['values'] = buf
+            data['txt'] = True
+
+        data['meta'] = meta
+        return data
+
+    def restore_pandas(self, data):
+        if data.get('txt', True):
+            # It's just text...
+            buf = data['values']
+        else:
+            buf = b64decode(data['values'])
+            if data.get('comp', False):
+                buf = self.compression.decompress(buf).decode()
+        meta = data.get('meta', {})
+        return buf,meta
+
+
+class PandasDfHandler(BaseHandler):
+    pp = PandasProcessor()
+
+    def flatten(self, obj, data):
+        # TODO: handle multi-index
+        dtype = obj.dtypes.to_dict()
+        meta = {'dtypes': {k:str(dtype[k]) for k in dtype}, 'index_col': 0}
+        data = self.pp.flatten_pandas(obj.to_csv(), data, meta)
+        return data
+
+    def restore(self, data):
+        csv,meta = self.pp.restore_pandas(data)
+        dtype = meta['dtypes'] if 'dtypes' in meta else None
+        df = pd.read_csv(StringIO(csv), index_col=meta.get('index_col', None), dtype=dtype)
+        return df
+
+class PandasSeriesHandler(BaseHandler):
+    pp = PandasProcessor()
+
+    def flatten(self, obj, data):
+        dtypes = {k:str(pd.np.dtype(type(obj[k]))) for k in obj.keys()}
+        meta = {'dtypes': dtypes, 'name': obj.name}
+        # Save series as two rows rather than two cols to make preserving type easier
+        data = self.pp.flatten_pandas(obj.to_frame().T.to_csv(), data, meta)
+        return data
+
+    def restore(self, data):
+        csv,meta = self.pp.restore_pandas(data)
+        dtypes = meta['dtypes'] if 'dtypes' in meta else None
+        df = pd.read_csv(StringIO(csv), dtype=dtypes)
+        ser = pd.Series(data=df.iloc[:,1:].values[0], index=df.columns[1:].values, name=meta.get('name', None))
+        return ser
+
+class PandasIndexHandler(BaseHandler):
+    pp = PandasProcessor()
+
+    def flatten(self, obj, data):
+        meta = {'dtype': str(obj.dtype), 'name': obj.name}
+        buf = json.dumps(obj.tolist())
+        data = self.pp.flatten_pandas(buf, data, meta)
+        return data
+
+    def restore(self, data):
+        buf,meta = self.pp.restore_pandas(data)
+        dtype = meta.get('dtype', None)
+        name = meta.get('name', None)
+        idx = pd.Index(json.loads(buf), dtype=dtype, name=name)
+        return idx
+
+
+def register_handlers():
+    register(pd.DataFrame, PandasDfHandler, base=True)
+    register(pd.Series, PandasSeriesHandler, base=True)
+    register(pd.Index, PandasIndexHandler, base=True)
+
+
+def unregister_handlers():
+    unregister(pd.DataFrame)
+    unregister(pd.Series)
+    unregister(pd.Index)
+

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -350,6 +350,14 @@ class NumpyTestCase(SkippableTest):
         handlers.registry.register(np.ndarray, handler, base=True)
         self.roundtrip(np.array([0, 1]))
 
+    def test_ndarray_dtype_object(self):
+        a = np.array(['F'+str(i) for i in range(30)], dtype=np.object)
+        buf = jsonpickle.encode(a)
+        # This is critical for reproducing the numpy segfault issue when restoring ndarray of dtype object
+        del a
+        _a = jsonpickle.decode(buf)
+        a = np.array(['F'+str(i) for i in range(30)], dtype=np.object)
+        npt.assert_array_equal(a, _a)
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import, division, unicode_literals
+import unittest
+import datetime
+import warnings
+
+import jsonpickle
+from jsonpickle import handlers
+from jsonpickle.compat import PY2, PY3
+
+from helper import SkippableTest
+
+try:
+    import pandas as pd
+    import numpy as np
+    from pandas.testing import assert_series_equal, assert_frame_equal
+
+except ImportError:
+    np = None
+
+
+class PandasTestCase(SkippableTest):
+
+    def setUp(self):
+        if np is None:
+            self.should_skip = True
+            return
+        self.should_skip = False
+        import jsonpickle.ext.pandas
+        jsonpickle.ext.pandas.register_handlers()
+
+    def tearDown(self):
+        if self.should_skip:
+            return
+        import jsonpickle.ext.pandas
+        jsonpickle.ext.pandas.unregister_handlers()
+
+    def roundtrip(self, obj):
+        return jsonpickle.decode(jsonpickle.encode(obj))
+
+    def test_series_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+        ser = pd.Series({
+                'an_int':np.int_(1),
+                'a_float':np.float_(2.5),
+                'a_nan':np.nan,
+                'a_minus_inf':-np.inf,
+                'an_inf':np.inf,
+                'a_str':np.str_('foo'),
+                'a_unicode':np.unicode_('bar'),
+                # TODO: the following dtypes are not currently supported.
+                #'object':np.object_({'a': 'b'}),
+                #'date':np.datetime64('2014-01-01'),
+                #'complex':np.complex_(1 - 2j)
+            })
+        decoded_ser = self.roundtrip(ser)
+        assert_series_equal(decoded_ser, ser)
+
+    def test_dataframe_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+        df = pd.DataFrame({
+                'an_int':np.int_([1,2,3]),
+                'a_float':np.float_([2.5,3.5,4.5]),
+                'a_nan':np.array([np.nan]*3),
+                'a_minus_inf':np.array([-np.inf]*3),
+                'an_inf':np.array([np.inf]*3),
+                'a_str':np.str_('foo'),
+                'a_unicode':np.unicode_('bar'),
+                # TODO: the following dtypes are not currently supported.
+                #'object':np.object_([{'a': 'b'}]*3),
+                #'date':np.array([np.datetime64('2014-01-01')]*3),
+                #'complex':np.complex_([1 - 2j, 2-1.2j, 3-1.3j])
+            })
+        decoded_df = self.roundtrip(df)
+        assert_frame_equal(decoded_df, df)
+
+    def test_b64(self):
+        """Test the binary encoding"""
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+        a = np.random.rand(20, 10)  # array of substantial size is stored as b64
+        index = ['Row'+str(i) for i in range(1, a.shape[0]+1)]
+        columns = ['Col'+str(i) for i in range(1, a.shape[1]+1)]
+        df = pd.DataFrame(a, index=index, columns=columns)
+        decoded_df = self.roundtrip(df)
+        assert_frame_equal(decoded_df, df)
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(PandasTestCase, 'test'))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add basic support for pandas objects (DataFrame, Series, and Index are
supported). Also fixes a regression in numpy ndarray support, and a
work-around for a numpy bug where decoding a byte-encoded ndarray of
type object causes a segfault.