### PR TITLE
Add stage for deploying to PyPI on tagged commits.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,32 @@
 sudo: false
 language: python
-matrix:
+
+python:
+- 2.7
+- 3.4
+- 3.5
+- &latest_py3 3.6
+
+env: TOXENV=python
+
+jobs:
+  fast_finish: true
   include:
-    - env: TOXENV=py27
-      python: 2.7
-    - env: TOXENV=py34
-      python: 3.4
-    - env: TOXENV=py35
-      python: 3.5
-    - env: TOXENV=py36
-      python: 3.6
+  - stage: deploy
+    if: tag IS present
+    python: *latest_py3
+    install: skip
+    script: skip
+    deploy:
+      provider: pypi
+      on:
+        tags: true
+        all_branches: true
+      user: jaraco
+      password:
+        secure: LZwSEE+UMTtwPsRF7Bdfz9pPa6bGnvSqIUEuKxJ4eqwguP6HhsVGRkg6pj6WVyz4+zqOwgBtF8nu6Ul1I9MlOYjhOeI/1BXHSW4AuuFc8GFNEI0O/22dpbaXKl3Va2iVbb0np5iVw8tMlnJDLe9zjEeuPgk/y0j9+x8x81iw0nM=
+      distributions: dists
+      skip_cleanup: true
 
 install:
   - "pip install tox"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[aliases]
+dists = clean --all sdist bdist_wheel
+
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ deps =
     coverage
     libs: demjson
     ecdsa
-    py{27}: enum34
+    enum34; python_version=="2.7"
     feedparser
-    py{27}: jsonlib
+    jsonlib; python_version=="2.7"
     nose
     numpy
     pymongo


### PR DESCRIPTION
Although untested, this work is based on the technique I use in my other projects.

Any tagged commit will be automatically released to PyPI.

You may want to test by tagging a 1.0.1b1 or similar.

It's currently configured to use my credentials, so should work as long as I'm a maintainer on the PyPI project. You're welcome to replace the credentials with your own. Just use the `travis encrypt` command.