### PR TITLE
Enabling pandas.dataframe multi-index restoration 

### DIFF
--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -59,7 +59,7 @@ class PandasDfHandler(BaseHandler):
         dtype = obj.dtypes.to_dict()
 
         # Handles named multi-indexes
-        index_col = obj.index.names if list(obj.index.names) != [None] else 0
+        index_col = list(obj.index.names) if list(obj.index.names) != [None] else 0
 
         meta = {'dtypes': {k: str(dtype[k]) for k in dtype},
                 'index_col': index_col}
@@ -70,6 +70,7 @@ class PandasDfHandler(BaseHandler):
     def restore(self, data):
         csv, meta = self.pp.restore_pandas(data)
         dtype = meta['dtypes'] if 'dtypes' in meta else None
+
         df = pd.read_csv(StringIO(csv),
                          index_col=meta.get('index_col', None),
                          dtype=dtype)

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -56,9 +56,14 @@ class PandasDfHandler(BaseHandler):
     pp = PandasProcessor()
 
     def flatten(self, obj, data):
-        # TODO: handle multi-index
         dtype = obj.dtypes.to_dict()
-        meta = {'dtypes': {k: str(dtype[k]) for k in dtype}, 'index_col': 0}
+
+        # Handles named multi-indexes
+        index_col = obj.index.names if list(obj.index.names) != [None] else 0
+
+        meta = {'dtypes': {k: str(dtype[k]) for k in dtype},
+                'index_col': index_col}
+
         data = self.pp.flatten_pandas(obj.to_csv(), data, meta)
         return data
 

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -37,18 +37,18 @@ class PandasTestCase(SkippableTest):
         if self.should_skip:
             return self.skip('pandas is not importable')
         ser = pd.Series({
-                'an_int': np.int_(1),
-                'a_float': np.float_(2.5),
-                'a_nan': np.nan,
-                'a_minus_inf': -np.inf,
-                'an_inf': np.inf,
-                'a_str': np.str_('foo'),
-                'a_unicode': np.unicode_('bar'),
-                # TODO: the following dtypes are not currently supported.
-                # 'object': np.object_({'a': 'b'}),
-                # 'date': np.datetime64('2014-01-01'),
-                # 'complex': np.complex_(1 - 2j)
-            })
+            'an_int': np.int_(1),
+            'a_float': np.float_(2.5),
+            'a_nan': np.nan,
+            'a_minus_inf': -np.inf,
+            'an_inf': np.inf,
+            'a_str': np.str_('foo'),
+            'a_unicode': np.unicode_('bar'),
+            # TODO: the following dtypes are not currently supported.
+            # 'object': np.object_({'a': 'b'}),
+            # 'date': np.datetime64('2014-01-01'),
+            # 'complex': np.complex_(1 - 2j)
+        })
         decoded_ser = self.roundtrip(ser)
         assert_series_equal(decoded_ser, ser)
 
@@ -56,18 +56,39 @@ class PandasTestCase(SkippableTest):
         if self.should_skip:
             return self.skip('pandas is not importable')
         df = pd.DataFrame({
-                'an_int': np.int_([1, 2, 3]),
-                'a_float': np.float_([2.5, 3.5, 4.5]),
-                'a_nan': np.array([np.nan]*3),
-                'a_minus_inf': np.array([-np.inf]*3),
-                'an_inf': np.array([np.inf]*3),
-                'a_str': np.str_('foo'),
-                'a_unicode': np.unicode_('bar'),
-                # TODO: the following dtypes are not currently supported.
-                # 'object': np.object_([{'a': 'b'}]*3),
-                # 'date': np.array([np.datetime64('2014-01-01')]*3),
-                # 'complex': np.complex_([1 - 2j, 2-1.2j, 3-1.3j])
-            })
+            'an_int': np.int_([1, 2, 3]),
+            'a_float': np.float_([2.5, 3.5, 4.5]),
+            'a_nan': np.array([np.nan] * 3),
+            'a_minus_inf': np.array([-np.inf] * 3),
+            'an_inf': np.array([np.inf] * 3),
+            'a_str': np.str_('foo'),
+            'a_unicode': np.unicode_('bar'),
+            # TODO: the following dtypes are not currently supported.
+            # 'object': np.object_([{'a': 'b'}]*3),
+            # 'date': np.array([np.datetime64('2014-01-01')]*3),
+            # 'complex': np.complex_([1 - 2j, 2-1.2j, 3-1.3j])
+        })
+        decoded_df = self.roundtrip(df)
+        assert_frame_equal(decoded_df, df)
+
+    def test_multindex_dataframe_roundtrip(self):
+        # if self.should_skip:
+        #     return self.skip('pandas is not importable')
+
+        df = pd.DataFrame({
+            'idx_lvl0': ['a', 'b', 'c'],
+            'idx_lvl1': np.int_([1, 1, 2]),
+            'an_int': np.int_([1, 2, 3]),
+            'a_float': np.float_([2.5, 3.5, 4.5]),
+            'a_nan': np.array([np.nan] * 3),
+            'a_minus_inf': np.array([-np.inf] * 3),
+            'an_inf': np.array([np.inf] * 3),
+            'a_str': np.str_('foo'),
+            'a_unicode': np.unicode_('bar'),
+        })
+
+        df.set_index(['idx_lvl0', 'idx_lvl1', ], inplace=True)
+
         decoded_df = self.roundtrip(df)
         assert_frame_equal(decoded_df, df)
 
@@ -75,9 +96,10 @@ class PandasTestCase(SkippableTest):
         """Test the binary encoding"""
         if self.should_skip:
             return self.skip('pandas is not importable')
-        a = np.random.rand(20, 10)  # array of substantial size is stored as b64
-        index = ['Row'+str(i) for i in range(1, a.shape[0]+1)]
-        columns = ['Col'+str(i) for i in range(1, a.shape[1]+1)]
+        # array of substantial size is stored as b64
+        a = np.random.rand(20, 10)
+        index = ['Row' + str(i) for i in range(1, a.shape[0] + 1)]
+        columns = ['Col' + str(i) for i in range(1, a.shape[1] + 1)]
         df = pd.DataFrame(a, index=index, columns=columns)
         decoded_df = self.roundtrip(df)
         assert_frame_equal(decoded_df, df)

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -72,8 +72,8 @@ class PandasTestCase(SkippableTest):
         assert_frame_equal(decoded_df, df)
 
     def test_multindex_dataframe_roundtrip(self):
-        # if self.should_skip:
-        #     return self.skip('pandas is not importable')
+        if self.should_skip:
+            return self.skip('pandas is not importable')
 
         df = pd.DataFrame({
             'idx_lvl0': ['a', 'b', 'c'],
@@ -86,8 +86,7 @@ class PandasTestCase(SkippableTest):
             'a_str': np.str_('foo'),
             'a_unicode': np.unicode_('bar'),
         })
-
-        df.set_index(['idx_lvl0', 'idx_lvl1', ], inplace=True)
+        df = df.set_index(['idx_lvl0', 'idx_lvl1', ])
 
         decoded_df = self.roundtrip(df)
         assert_frame_equal(decoded_df, df)


### PR DESCRIPTION
As discussed in #213, this is a [slight change](https://github.com/guilhemchalancon/jsonpickle/blob/93b7bca295df1c858d5b848098b8d2a273355233/jsonpickle/ext/pandas.py#L62) in the `PandasDfHandler.flatten` method to preserve pandas MultiIndex. 

I didn't have to touch the `PandasIndexHandler` for the change to work. 
I've added [`test_multindex_dataframe_roundtrip`](https://github.com/guilhemchalancon/jsonpickle/blob/93b7bca295df1c858d5b848098b8d2a273355233/tests/pandas_test.py#L74) to the pandas test case.  

I hope this helps. 

 