### PR TITLE
Add Base85 encoding support for Python 3

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,15 @@ Version 1.2 - TBD 2019
       These objects are now handled robustly.
       (`#247 <https://github.com/jsonpickle/jsonpickle/issues/247>`_).
 
+    * `Base85`_ is now the default binary data encoding on Python 3, as it's
+      more space-efficient than base64. Python 3 can still read and write
+      base64-encoded data, but Python 2 cannot read nor write base85. For
+      backwards compatibility, the pickler can be configured to encode using
+      only base64 via the new ``prefer_base85`` argument.
+      (`#251 <https://github.com/jsonpickle/jsonpickle/issues/251>`_).
+
+.. _Base85: https://en.wikipedia.org/wiki/Ascii85
+
 Version 1.1 - January 22, 2019
 ------------------------------
     * Python 3.7 `collections.Iterator` deprecation warnings have been fixed.

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 BYTES = 'py/bytes'
 B64 = 'py/b64'
+B85 = 'py/b85'
 FUNCTION = 'py/function'
 ID = 'py/id'
 INITARGS = 'py/initargs'

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -12,7 +12,7 @@ from . import compat
 from . import util
 from . import tags
 from . import handlers
-from .compat import numeric_types, decodebytes
+from .compat import numeric_types
 from .backend import json
 
 
@@ -169,6 +169,8 @@ class Unpickler(object):
     def _restore(self, obj):
         if has_tag(obj, tags.B64):
             restore = self._restore_base64
+        elif has_tag(obj, tags.B85):
+            restore = self._restore_base85
         elif has_tag(obj, tags.BYTES):  # Backwards compatibility
             restore = self._restore_quopri
         elif has_tag(obj, tags.ID):
@@ -201,7 +203,10 @@ class Unpickler(object):
         return restore(obj)
 
     def _restore_base64(self, obj):
-        return decodebytes(obj[tags.B64].encode('utf-8'))
+        return util.b64decode(obj[tags.B64].encode('utf-8'))
+
+    def _restore_base85(self, obj):
+        return util.b85decode(obj[tags.B85].encode('utf-8'))
 
     #: For backwards compatibility with bytes data produced by older versions
     def _restore_quopri(self, obj):

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -511,7 +511,25 @@ def b64decode(payload):
     """
     Decode payload - must be ascii text.
     """
-    return base64.b64decode(payload.encode('ascii'))
+    return base64.b64decode(payload)
+
+
+def b85encode(data):
+    """
+    Encode binary data to ascii text in base85. Data must be bytes.
+    """
+    if PY2:
+        raise NotImplementedError("Python 2 can't encode data in base85.")
+    return base64.b85encode(data).decode('ascii')
+
+
+def b85decode(payload):
+    """
+    Decode payload - must be ascii text.
+    """
+    if PY2:
+        raise NotImplementedError("Python 2 can't decode base85-encoded data.")
+    return base64.b85decode(payload)
 
 
 def itemgetter(obj, getter=operator.itemgetter(0)):

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -103,6 +103,59 @@ class PicklingTestCase(unittest.TestCase):
         self.pickler.reset()
         self.unpickler.reset()
 
+    @unittest.skipIf(not PY2, 'Python 2-specific base85 test')
+    def test_base85_always_false_on_py2(self):
+        pickler = jsonpickle.pickler.Pickler(prefer_base85=True)
+        self.assertFalse(pickler.prefer_base85)
+
+    @unittest.skipIf(PY2, 'Base85 not supported on Python 2')
+    def test_base85_default_py3(self):
+        """Ensure Python 2 allows prefer_base85 as default on Python 3"""
+        pickler = jsonpickle.pickler.Pickler()
+        self.assertTrue(pickler.prefer_base85)
+
+    @unittest.skipIf(PY2, 'Base85 not supported on Python 2')
+    def test_base85_override_py3(self):
+        """Ensure the Python 2 check still lets us set prefer_base85 on Python 3"""
+        pickler = jsonpickle.pickler.Pickler(prefer_base85=False)
+        self.assertFalse(pickler.prefer_base85)
+
+    @unittest.skipIf(PY2, 'Base85 not supported on Python 2')
+    def test_bytes_default_base85(self):
+        data = os.urandom(16)
+        encoded = util.b85encode(data)
+        self.assertEqual({tags.B85: encoded}, self.pickler.flatten(data))
+
+    @unittest.skipIf(PY2, 'Base85 not supported on Python 2')
+    def test_py3_bytes_base64_override(self):
+        pickler = jsonpickle.pickler.Pickler(prefer_base85=False)
+        data = os.urandom(16)
+        encoded = util.b64encode(data)
+        self.assertEqual({tags.B64: encoded}, pickler.flatten(data))
+
+    @unittest.skipIf(not PY2, 'Python 2-specific base64 test')
+    def test_py2_default_base64(self):
+        data = os.urandom(16)
+        encoded = util.b64encode(data)
+        self.assertEqual({tags.B64: encoded}, self.pickler.flatten(data))
+
+    @unittest.skipIf(PY2, 'Base85 not supported on Python 2')
+    def test_decode_base85(self):
+        pickled = {tags.B85: 'P{Y4;Xv4O{u^=-c'}
+        expected = u'P\u00ffth\u00f6\u00f1 3!'.encode('utf-8')
+        self.assertEqual(expected, self.unpickler.restore(pickled))
+
+    @unittest.skipIf(PY2, 'Base85 not supported on Python 2')
+    def test_base85_still_handles_base64(self):
+        pickled = {tags.B64: 'UMO/dGjDtsOxIDMh'}
+        expected = u'P\u00ffth\u00f6\u00f1 3!'.encode('utf-8')
+        self.assertEqual(expected, self.unpickler.restore(pickled))
+
+    @unittest.skipIf(not PY2, 'Python 2-specific base85 test')
+    def test_base85_crashes_py2(self):
+        with self.assertRaises(NotImplementedError):
+            self.unpickler.restore({tags.B85: 'P{Y4;Xv4O{u^=-c'})
+
     def test_string(self):
         self.assertEqual('a string', self.pickler.flatten('a string'))
         self.assertEqual('a string', self.unpickler.restore('a string'))

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -15,6 +15,13 @@ from jsonpickle.compat import queue, PY2, encodebytes
 
 from helper import SkippableTest
 
+if PY2:
+    default_bytes_encoder = util.b64encode
+    default_bytes_tag = tags.B64
+else:
+    default_bytes_encoder = util.b85encode
+    default_bytes_tag = tags.B85
+
 
 class Thing(object):
 
@@ -809,9 +816,9 @@ class AdvancedObjectsTestCase(SkippableTest):
             self.assertTrue(isinstance(encoded, compat.ustr))
         else:
             self.assertNotEqual(encoded, u1)
-            b64ustr = encodebytes(b'foo').decode('utf-8')
-            self.assertEqual({tags.B64: b64ustr}, encoded)
-            self.assertTrue(isinstance(encoded[tags.B64], compat.ustr))
+            encoded_ustr = default_bytes_encoder(b'foo')
+            self.assertEqual({default_bytes_tag: encoded_ustr}, encoded)
+            self.assertTrue(isinstance(encoded[default_bytes_tag], compat.ustr))
         decoded = self.unpickler.restore(encoded)
         self.assertTrue(decoded == b1)
         if PY2:
@@ -822,9 +829,9 @@ class AdvancedObjectsTestCase(SkippableTest):
         # bytestrings that we can't decode to UTF-8 will always be wrapped
         encoded = self.pickler.flatten(b2)
         self.assertNotEqual(encoded, b2)
-        b64ustr = encodebytes(b'foo\xff').decode('utf-8')
-        self.assertEqual({tags.B64: b64ustr}, encoded)
-        self.assertTrue(isinstance(encoded[tags.B64], compat.ustr))
+        encoded_ustr = default_bytes_encoder(b'foo\xff')
+        self.assertEqual({default_bytes_tag: encoded_ustr}, encoded)
+        self.assertTrue(isinstance(encoded[default_bytes_tag], compat.ustr))
         decoded = self.unpickler.restore(encoded)
         self.assertEqual(decoded, b2)
         self.assertTrue(isinstance(decoded, bytes))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -55,6 +55,16 @@ class MethodTestOldStyle:
 
 class UtilTestCase(unittest.TestCase):
 
+    @unittest.skipIf(not compat.PY2, 'Python 2-specific Base85 test')
+    def test_b85encode_crashes_on_python2(self):
+        with self.assertRaises(NotImplementedError):
+            util.b85encode(b'')
+
+    @unittest.skipIf(not compat.PY2, 'Python 2-specific Base85 test')
+    def test_b85decode_crashes_on_python2(self):
+        with self.assertRaises(NotImplementedError):
+            util.b85decode(u'RC2?pb0AN3baKO~')
+
     def test_is_primitive_int(self):
         self.assertTrue(util.is_primitive(0))
         self.assertTrue(util.is_primitive(3))


### PR DESCRIPTION
TL;DR: Allow using [Base85](https://en.wikipedia.org/wiki/Ascii85) text encoding on Python 3.

## Details

This doesn't remove base64 encoding support for Python 3; rather, it makes base85 the default but still allows overriding the default to only use base64 for backwards compatibility with Python 2. (Python 2 doesn't support base85, nor does there appear to be a backport for it.)

## Why
It's a more compact text encoding than Base64, and some manual experimentation gives about a 10% space savings for randomized binary data.

Closes #250.