### PR TITLE
Further Pandas Support

### DIFF
--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -114,7 +114,7 @@ class PandasSeriesHandler(BaseHandler):
 
 
 class PandasIndexHandler(BaseHandler):
-    pp = PandasProcessor(size_threshold=None)
+    pp = PandasProcessor()
 
     index_constructor = pd.Index
     name_bundler = lambda _, obj: {'name': obj.name}

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -137,10 +137,15 @@ class PandasIndexHandler(BaseHandler):
         return idx
 
 
+class PandasPeriodIndexHandler(PandasIndexHandler):
+    index_constructor = pd.PeriodIndex
+
+
 def register_handlers():
     register(pd.DataFrame, PandasDfHandler, base=True)
     register(pd.Series, PandasSeriesHandler, base=True)
     register(pd.Index, PandasIndexHandler, base=True)
+    register(pd.PeriodIndex, PandasPeriodIndexHandler, base=True)
 
 
 def unregister_handlers():

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -121,6 +121,8 @@ class PandasSeriesHandler(BaseHandler):
 class PandasIndexHandler(BaseHandler):
     pp = PandasProcessor(size_threshold=None)
 
+    index_constructor = pd.Index
+
     def flatten(self, obj, data):
         meta = {'dtype': str(obj.dtype), 'name': obj.name}
         buf = encode(obj.tolist())
@@ -131,7 +133,7 @@ class PandasIndexHandler(BaseHandler):
         buf, meta = self.pp.restore_pandas(data)
         dtype = meta.get('dtype', None)
         name = meta.get('name', None)
-        idx = pd.Index(decode(buf), dtype=dtype, name=name)
+        idx = self.index_constructor(decode(buf), dtype=dtype, name=name)
         return idx
 
 

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -4,6 +4,7 @@ import pandas as pd
 from io import StringIO
 import zlib
 
+from .. import encode, decode
 from ..handlers import BaseHandler, register, unregister
 from ..util import b64decode, b64encode
 from ..backend import json
@@ -122,7 +123,7 @@ class PandasIndexHandler(BaseHandler):
 
     def flatten(self, obj, data):
         meta = {'dtype': str(obj.dtype), 'name': obj.name}
-        buf = json.dumps(obj.tolist())
+        buf = encode(obj.tolist())
         data = self.pp.flatten_pandas(buf, data, meta)
         return data
 
@@ -130,7 +131,7 @@ class PandasIndexHandler(BaseHandler):
         buf, meta = self.pp.restore_pandas(data)
         dtype = meta.get('dtype', None)
         name = meta.get('name', None)
-        idx = pd.Index(json.loads(buf), dtype=dtype, name=name)
+        idx = pd.Index(decode(buf), dtype=dtype, name=name)
         return idx
 
 

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -119,7 +119,7 @@ class PandasSeriesHandler(BaseHandler):
 
 
 class PandasIndexHandler(BaseHandler):
-    pp = PandasProcessor()
+    pp = PandasProcessor(size_threshold=None)
 
     def flatten(self, obj, data):
         meta = {'dtype': str(obj.dtype), 'name': obj.name}

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -8,7 +8,7 @@ from helper import SkippableTest
 try:
     import pandas as pd
     import numpy as np
-    from pandas.testing import assert_series_equal, assert_frame_equal
+    from pandas.testing import assert_series_equal, assert_frame_equal, assert_index_equal
 
 except ImportError:
     np = None
@@ -90,6 +90,62 @@ class PandasTestCase(SkippableTest):
 
         decoded_df = self.roundtrip(df)
         assert_frame_equal(decoded_df, df)
+
+    def test_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.Index(range(5, 10))
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_datetime_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.date_range(start='2019-01-01', end='2019-02-01', freq='D')
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_timedelta_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.timedelta_range(start='1 day', periods=4, closed='right')
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_period_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.period_range(start='2017-01-01', end='2018-01-01', freq='M')
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_int64_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.Int64Index([-1, 0, 3, 4])
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_uint64_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.UInt64Index([0, 3, 4])
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_float64_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.Float64Index([0.1, 3.7, 4.2])
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
 
     def test_b64(self):
         """Test the binary encoding"""

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -91,6 +91,16 @@ class PandasTestCase(SkippableTest):
         decoded_df = self.roundtrip(df)
         assert_frame_equal(decoded_df, df)
 
+    def test_dataframe_with_interval_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]},
+                           index=pd.IntervalIndex.from_breaks([1,2,4]))
+
+        decoded_df = self.roundtrip(df)
+        assert_frame_equal(decoded_df, df)
+
     def test_index_roundtrip(self):
         if self.should_skip:
             return self.skip('pandas is not importable')
@@ -168,6 +178,14 @@ class PandasTestCase(SkippableTest):
             return self.skip('pandas is not importable')
 
         idx = pd.IntervalIndex.from_breaks(pd.date_range('2019-01-01', '2019-01-10'))
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_multi_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.MultiIndex.from_product(((1,2,3), ("a", "b")))
         decoded_idx = self.roundtrip(idx)
         assert_index_equal(decoded_idx, idx)
 

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -107,6 +107,14 @@ class PandasTestCase(SkippableTest):
         decoded_idx = self.roundtrip(idx)
         assert_index_equal(decoded_idx, idx)
 
+    def test_ragged_datetime_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.DatetimeIndex(['2019-01-01', '2019-01-02', '2019-01-05',])
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
     def test_timedelta_index_roundtrip(self):
         if self.should_skip:
             return self.skip('pandas is not importable')

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -155,6 +155,46 @@ class PandasTestCase(SkippableTest):
         decoded_idx = self.roundtrip(idx)
         assert_index_equal(decoded_idx, idx)
 
+    def test_interval_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.IntervalIndex.from_breaks(range(5))
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_datetime_interval_index_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        idx = pd.IntervalIndex.from_breaks(pd.date_range('2019-01-01', '2019-01-10'))
+        decoded_idx = self.roundtrip(idx)
+        assert_index_equal(decoded_idx, idx)
+
+    def test_timestamp_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        obj = pd.Timestamp('2019-01-01')
+        decoded_obj = self.roundtrip(obj)
+        assert decoded_obj == obj
+
+    def test_period_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        obj = pd.Timestamp('2019-01-01')
+        decoded_obj = self.roundtrip(obj)
+        assert decoded_obj == obj
+
+    def test_interval_roundtrip(self):
+        if self.should_skip:
+            return self.skip('pandas is not importable')
+
+        obj = pd.Interval(2, 4, closed=str('left'))
+        decoded_obj = self.roundtrip(obj)
+        assert decoded_obj == obj
+
     def test_b64(self):
         """Test the binary encoding"""
         if self.should_skip:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -26,6 +26,7 @@ import util_test
 import feedparser_test
 import bson_test
 import numpy_test
+import pandas_test
 
 
 def suite():
@@ -41,6 +42,7 @@ def suite():
     suite.addTest(feedparser_test.suite())
     suite.addTest(numpy_test.suite())
     suite.addTest(bson_test.suite())
+    suite.addTest(pandas_test.suite())
     return suite
 
 


### PR DESCRIPTION
The pandas extension library fails under certain use cases.  In particular, non-standard indexes on data frames will not serialize/unserialize correctly.  In certain cases, an error is even thrown upon serialization.  This PR aims to handle pandas objects better in the pandas extension library.

The main thrust of this PR is that a `pandas.DataFrame` will now be saved with its index not appearing in the `value` portion of the serialization. Instead the index is saved entirely separately in the `index` key of the `meta` portion of the serialization. Further, additional handlers have been added for several different types of indexes (though most of the code between them is reused). Handlers were also added for timestamps, periods, and intervals.

For more context of what doesn't work in the current handler:
```
import pandas as pd
from pandas.testing import assert_frame_equal

import jsonpickle as jp
import jsonpickle.ext.pandas
jp.ext.pandas.register_handlers()

def roundtrip(obj):
    return jp.decode(jp.encode(obj))

df = pd.DataFrame({"a": [1, 2], "b": ["foo", "bar"]})
assert_frame_equal(df, roundtrip(df)) # this is fine

idx = pd.Index(pd.date_range('2019-01-01', '2019-01-02'))
df.set_index(idx, inplace=True)
assert_frame_equal(df, rountrip(df)) # this assertion fails because the index of df comes back as object type instead of DatetimeIndex type

idx = pd.IntervalIndex.from_breaks(range(3))
df.set_index(idx, inplace=True)
jp.encode(df) # this already fails seemingly due to a bug with pd.DataFrame.to_csv
```