### PR TITLE
fix #259 prevent stackoverflow in _getstate

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -593,7 +593,7 @@ class Pickler(object):
                                       make_refs=self.make_refs)
 
     def _getstate(self, obj, data):
-        state = self._flatten_obj(obj)
+        state = self._flatten(obj)
         if self.unpicklable:
             data[tags.STATE] = state
         else:

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -76,6 +76,10 @@ class GetstateReturnsList(object):
     def __setstate__(self, state):
         self.x, self.y = state[0], state[1]
 
+class GetstateRecursesInfintely(object):
+    def __getstate__(self):
+        return GetstateRecursesInfintely()
+
 
 class ListSubclassWithInit(list):
 
@@ -716,6 +720,11 @@ class AdvancedObjectsTestCase(SkippableTest):
         self.assertEqual(expect, actual)
         restored = self.unpickler.restore(flat)
         self.assertEqual(expect, restored)
+
+    def test_getstate_does_not_recurse_infinitely(self):
+        obj = GetstateRecursesInfintely()
+        pickler = jsonpickle.pickler.Pickler(max_depth=5)
+        pickler.flatten(obj)
 
     def test_thing_with_queue(self):
         obj = ThingWithQueue()


### PR DESCRIPTION
see https://github.com/jsonpickle/jsonpickle/issues/259

flatten will increase the depth, thus preventing a stackoverflow.