### PR TITLE
don't emit null optional arguments for `py/reduce`

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -411,7 +411,11 @@ class Pickler(object):
                     if rv_as_list[4]:
                         rv_as_list[4] = tuple(rv_as_list[4])
 
-                    data[tags.REDUCE] = list(map(self._flatten, rv_as_list))
+                    reduce_args = list(map(self._flatten, rv_as_list))
+                    last_index = len(reduce_args) - 1
+                    while last_index >= 2 and reduce_args[last_index] is None:
+                        last_index -= 1
+                    data[tags.REDUCE] = reduce_args[:last_index+1]
 
                     return data
 

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -227,8 +227,10 @@ class Unpickler(object):
         """
         proxy = _Proxy()
         self._mkref(proxy)
-        reduce_val = obj[tags.REDUCE]
-        f, args, state, listitems, dictitems = map(self._restore, reduce_val)
+        reduce_val = list(map(self._restore, obj[tags.REDUCE]))
+        if len(reduce_val) < 5:
+            reduce_val.extend([None] * (5 - len(reduce_val)))
+        f, args, state, listitems, dictitems = reduce_val
 
         if f == tags.NEWOBJ or getattr(f, '__name__', '') == '__newobj__':
             # mandated special case


### PR DESCRIPTION
The last three elements of [`__reduce__`](https://docs.python.org/3/library/pickle.html#object.__reduce__) are optional and are typically `None`. This PR omits trailing `null`s in `py/reduce` to make the JSON slightly nicer.

Related to #241.