### PR TITLE
Remove redondant call to importable_name

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -417,7 +417,6 @@ class Pickler(object):
 
         if has_class and not util.is_module(obj):
             if self.unpicklable:
-                class_name = util.importable_name(cls)
                 data[tags.OBJECT] = class_name
 
             if has_getnewargs_ex:


### PR DESCRIPTION
The variable `class_name` is already defined at line 345, there is no need to recall `importable_name` after that in the same function, since `cls` doesn't change between the two calls.