### PR TITLE
Fix: restoring an empty Pandas DF fails

### DIFF
--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -87,8 +87,8 @@ class PandasDfHandler(BaseHandler):
     def restore(self, data):
         csv, meta = self.pp.restore_pandas(data)
         params = make_read_csv_params(meta)
-        df = pd.read_csv(StringIO(csv),
-                         **params)
+        df = pd.read_csv(
+          StringIO(csv), **params) if data['values'].strip() else pd.DataFrame()
         df.set_index(decode(meta['index']), inplace=True)
         return df
 


### PR DESCRIPTION
read_csv cannot read a file w/o columns. Check if file to restore from is empty (\r\n), create new dataframe if needed.