### PR TITLE
speed improvement for long lists of primitives

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -223,6 +223,24 @@ class Pickler(object):
         return self._flatten(obj)
 
     def _flatten(self, obj):
+
+        #########################################
+        # if obj is nonrecursive return immediately
+        # for performance reasons we don't want to do recursive checks
+        if PY2 and isinstance(obj, types.FileType):
+            return self._flatten_file(obj)
+
+        if util.is_bytes(obj):
+            return self._flatten_bytestring(obj)
+
+        if util.is_primitive(obj):
+            return obj
+
+        # Decimal is a primitive when use_decimal is True
+        if self._use_decimal and isinstance(obj, decimal.Decimal):
+            return obj
+        #########################################
+
         self._push()
         return self._pop(self._flatten_obj(obj))
 
@@ -261,19 +279,6 @@ class Pickler(object):
         return [self._flatten(v) for v in obj]
 
     def _get_flattener(self, obj):
-
-        if PY2 and isinstance(obj, types.FileType):
-            return self._flatten_file
-
-        if util.is_bytes(obj):
-            return self._flatten_bytestring
-
-        if util.is_primitive(obj):
-            return lambda obj: obj
-
-        # Decimal is a primitive when use_decimal is True
-        if self._use_decimal and isinstance(obj, decimal.Decimal):
-            return lambda obj: obj
 
         list_recurse = self._list_recurse
 


### PR DESCRIPTION
I was wondering why `x = [[i for i in range(10000000)]]` took so long to calculate in [arepl](https://github.com/Almenon/AREPL-vscode) compared to native python. I used cProfile+snakeviz and found out that jsonpickle was taking up most of the time. 

Before fix:
![](https://i.imgur.com/CuhHpCR.png)

After fix:
![](https://i.imgur.com/urEgIKN.png)

Jsonpickle does some recursion checks to make sure it doesn't recurse forever. By checking if the type is a non-recursive type and flattening immediately if so there is a ~70% performance gain.

Hopefully this change doesn't break anything. I still need to test this a bit more.