### PR TITLE
wip: datetime: use isoformat for datetime objects rather than __reduce__()

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,9 @@ Change Log
 
 Version 1.4 - TBD
 -----------------
+    * `datetime.datetime` objects are now represented in a more
+      human-readable format.
+      (`#109 <https://github.com/jsonpickle/jsonpickle/issues/109>`_)
     * We now include a custom handler for `array.array` objects.
       (`#199 <https://github.com/jsonpickle/jsonpickle/issues/199>`_)
     * Dict key order is preserved when pickling dictionaries on Python3.

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -201,7 +201,7 @@ class DateTimeAdvancedTestCase(unittest.TestCase):
 
         flattened = self.pickler.flatten(obj)
         self.assertTrue(tags.OBJECT in flattened)
-        self.assertTrue('__reduce__' in flattened)
+        self.assertTrue('iso' in flattened)
 
         inflated = self.unpickler.restore(flattened)
         self.assertEqual(obj, inflated)


### PR DESCRIPTION
Slightly simplify the datetime representation by storing
the ISO format and tzinfo objects separately.  This allows
us to have a slightly simpler JSON format for datetime objects.

Closes #109
Signed-off-by: David Aguilar <davvid@gmail.com>