### PR TITLE
Make readme warn about security implications (fixes #294)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ enable the numpy extension by registering its handlers::
     >>> jsonpickle_numpy.register_handlers()
 
 Pandas Support
-=============
+==============
 jsonpickle includes a built-in pandas extension.  If would like to encode
 pandas DataFrame or Series objects then you must enable the pandas extension
 by registering its handlers::

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,9 @@ Bug reports and merge requests are encouraged at the
 
 jsonpickle supports Python 2.7 and Python 3.4 or greater.
 
+    **WARNING**:
+    jsonpickle can execute arbitrary Python code. Do not load jsonpickles from untrusted / unauthenticated sources.
+
 Why jsonpickle?
 ===============
 Data serialized with python's pickle (or cPickle or dill) is not easily readable outside of python. Using the json format, jsonpickle allows simple data types to be stored in a human-readable format, and more complex data types such as numpy arrays and pandas dataframes, to be machine-readable on any platform that supports json. E.g., unlike pickled data, jsonpickled data stored in an Amazon S3 bucket is indexible by Amazon's Athena.


### PR DESCRIPTION
Fixes #294

(I would love to use a [warning admonition](https://docutils.sourceforge.io/docs/ref/rst/directives.html#admonitions) for this but [GitHub fails to render them properly](https://github.com/github/markup/issues/68).)

CC @davvid