### PR TITLE
Include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include COPYING README.rst
+include LICENSE README.rst
 include Rakefile
 include *.py
 include jsonpickle/*.py


### PR DESCRIPTION
The project switched from using the `COPYING` file to `LICENSE` at some point and it is not correctly reflected in the `MANIFEST.in`