### PR TITLE
Use importlib.metadata from the standard library on Python 3.8+

### DIFF
--- a/jsonpickle/version.py
+++ b/jsonpickle/version.py
@@ -1,5 +1,10 @@
+import sys
+
 try:
-    import importlib_metadata as metadata
+    if sys.version_info < (3, 8):
+        import importlib_metadata as metadata
+    else:
+        from importlib import metadata
 except (ImportError, OSError):
     metadata = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	importlib_metadata
+	importlib_metadata; python_version<"3.8"
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.extras_require]


### PR DESCRIPTION
Fixes https://github.com/jsonpickle/jsonpickle/issues/303