### PR TITLE
pickler: create copies of seen objects

### DIFF
--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -764,10 +764,10 @@ class JSONPickleTestCase(SkippableTest):
         encoded = jsonpickle.encode(thing, make_refs=False)
         decoded = jsonpickle.decode(encoded)
 
-        self.assertEqual(decoded.a[0], 1)
-        self.assertEqual(decoded.b[0:3], '[1,')
-        self.assertEqual(decoded.a[1][0:3], '[1,')
-        self.assertEqual(decoded.a[2][0][0:3], '[1,')
+        assert decoded.a[0] == 1
+        assert decoded.b[0] == 1
+        assert decoded.a[1][0:3] == '[1,'
+        assert decoded.a[2][0][0:3] == '[1,'
 
     def test_can_serialize_inner_classes(self):
         class InnerScope(object):
@@ -1522,9 +1522,9 @@ class PicklingProtocol2TestCase(SkippableTest):
         self.assertEqual(len(args), 2)
         decoded_child0 = args[0]
         decoded_child1 = args[1]
-        self.assertTrue(isinstance(decoded_child0, dict))
         # Circular references become None
-        self.assertEqual(decoded_child1, None)
+        assert decoded_child0 == {'args': [None], 'kwargs': {}}
+        assert decoded_child1 == {'args': [None], 'kwargs': {}}
 
     def test_cyclical_objects_unpickleable_false_list(self):
         self.test_cyclical_objects_unpickleable_false(use_tuple=False)

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -6,6 +6,7 @@ import datetime
 import decimal
 import re
 import threading
+import pytz
 
 import jsonpickle
 from jsonpickle import compat
@@ -1132,6 +1133,18 @@ def test_unicode_mixin():
     assert new_obj == 'test passed'
     assert isinstance(new_obj, UnicodeMixin)
     assert new_obj.ok()
+
+
+def test_datetime_with_tz_copies_refs():
+    """Ensure that we create copies of referenced objects"""
+    d0 = datetime.datetime(2020, 5, 5, 5, 5, 5, 5, tzinfo=pytz.UTC)
+    d1 = datetime.datetime(2020, 5, 5, 5, 5, 5, 5, tzinfo=pytz.UTC)
+    obj = [d0, d1]
+    encoded = jsonpickle.encode(obj, make_refs=False)
+    decoded = jsonpickle.decode(encoded)
+    assert len(decoded) == 2
+    assert decoded[0] == d0
+    assert decoded[1] == d1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously the make_refs=False / unpicklable=False code path
would avoid emitting data for objects it had already seen.
It mostly did this to avoid cycles, as its reference
system is disabled in these modes, and thus the result
was that null was emitted for any objects that appear
more than once in the object graph.

Improve the behavior by keeping track of objects that we
have already flattened and simply return the pre-flattened
representation when we re-encounter the same object.

This is a simple solution that fixes encoding of datetime
objects with UTC tzinfo in these scenarios.

Resolves #333 #334 #337
Signed-off-by: David Aguilar <davvid@gmail.com>