### PR TITLE
Micro-Optimization

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -15,7 +15,6 @@ from . import handlers
 from .compat import numeric_types
 from .backend import json
 
-
 def decode(
     string, backend=None, context=None, keys=False, reset=True, safe=False, classes=None
 ):
@@ -176,6 +175,13 @@ class Unpickler(object):
         self._proxies = []
 
     def _restore(self, obj):
+        try::
+            if not tags.RESERVED <= set(obj) and not type(obj) in (list, dict):
+                def restore(x):
+                    return x
+                return restore(obj)
+        except TypeError:
+            pass
         if has_tag(obj, tags.B64):
             restore = self._restore_base64
         elif has_tag(obj, tags.B85):

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -175,7 +175,7 @@ class Unpickler(object):
         self._proxies = []
 
     def _restore(self, obj):
-        try::
+        try:
             if not tags.RESERVED <= set(obj) and not type(obj) in (list, dict):
                 def restore(x):
                     return x

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -178,10 +178,10 @@ class Unpickler(object):
     def _restore(self, obj):
         try:
             if not tags.RESERVED <= set(obj) and not type(obj) in (list, dict):
-            
+
                 def restore(x):
                     return x
-                    
+
                 return restore(obj)
         except TypeError:
             pass

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -15,6 +15,7 @@ from . import handlers
 from .compat import numeric_types
 from .backend import json
 
+
 def decode(
     string, backend=None, context=None, keys=False, reset=True, safe=False, classes=None
 ):
@@ -177,8 +178,10 @@ class Unpickler(object):
     def _restore(self, obj):
         try:
             if not tags.RESERVED <= set(obj) and not type(obj) in (list, dict):
+            
                 def restore(x):
                     return x
+                    
                 return restore(obj)
         except TypeError:
             pass

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -180,24 +180,24 @@ class Unpickler(object):
             restore = self._restore_base64
         elif has_tag(obj, tags.B85):
             restore = self._restore_base85
-        elif has_tag(obj, tags.BYTES):  # Backwards compatibility
-            restore = self._restore_quopri
         elif has_tag(obj, tags.ID):
             restore = self._restore_id
-        elif has_tag(obj, tags.REF):  # Backwards compatibility
-            restore = self._restore_ref
         elif has_tag(obj, tags.ITERATOR):
             restore = self._restore_iterator
         elif has_tag(obj, tags.TYPE):
             restore = self._restore_type
-        elif has_tag(obj, tags.REPR):  # Backwards compatibility
-            restore = self._restore_repr
         elif has_tag(obj, tags.REDUCE):
             restore = self._restore_reduce
         elif has_tag(obj, tags.OBJECT):
             restore = self._restore_object
         elif has_tag(obj, tags.FUNCTION):
             restore = self._restore_function
+        elif has_tag(obj, tags.BYTES):  # Backwards compatibility
+            restore = self._restore_quopri
+        elif has_tag(obj, tags.REF):  # Backwards compatibility
+            restore = self._restore_ref
+        elif has_tag(obj, tags.REPR):  # Backwards compatibility
+            restore = self._restore_repr
         elif util.is_list(obj):
             restore = self._restore_list
         elif has_tag(obj, tags.TUPLE):


### PR DESCRIPTION
Currently, if you are trying to decode something with the object tag, it takes 10 ``if`` checks for previous tags. Because three of those are only for backwards compatibility, and most people probably don't use them, I decided to push them closer to the end. This shaves off about 20% of the time per call of ``Unpickler._restore`` on my VPS with some of my test data (mixed 'py/object' and 'py/state'), and it didn't fail any pytest tests.

I plan to submit more optimizations in the future, I see great potential in this library for use if speed and security are taken care of.