### PR TITLE
Large optimization to unpickler

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -771,4 +771,3 @@ def has_tag(obj, tag):
 
     """
     return type(obj) is dict and tag in obj
-    

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -771,3 +771,4 @@ def has_tag(obj, tag):
 
     """
     return type(obj) is dict and tag in obj
+    


### PR DESCRIPTION
I realized that in certain cases, actually a sizeable number of cases, we don't need to check if it has a tag because it's a float, or an int, or something else that can't contain a string tag. This doubles the speed of unpickling for my personal use case (which involves a large amount of ints/floats), and should provide a statistically significant speed increase for most other cases also.