### PR TITLE
serialization: preserve dictionary identity when un/pickling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ v1.5.1
     * ``decode()`` documentation improvements.  (+341)
     * Serialization of Pandas DataFrame objects that contain
       timedelta64[ns] dtypes are now supported.  (+330) (#331)
+    * Dictionary identity is now preserved.  For example, if the same
+      dictionary appears twice in a list, the reconstituted list
+      will now contain two references to the same dictionary.  (#255) (+332)
 
 v1.5.0
 ======

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -342,7 +342,11 @@ class Pickler(object):
             return lambda obj: {tags.SET: [self._flatten(v) for v in obj]}
 
         if util.is_dictionary(obj):
-            return self._flatten_dict_obj
+            if self._mkref(obj):
+                return self._flatten_dict_obj
+            else:
+                self._push()
+                return self._getref
 
         if util.is_type(obj):
             return _mktyperef

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -541,6 +541,7 @@ class Unpickler(object):
 
     def _restore_dict(self, obj):
         data = {}
+        self._mkref(data)
 
         # If we are decoding dicts that can have non-string keys then we
         # need to do a two-phase decode where the non-string keys are

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1,22 +1,21 @@
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
-# Copyright (C) 2009-2018 David Aguilar (davvid -at- gmail.com)
+# Copyright (C) 2009-2021 David Aguilar (davvid -at- gmail.com)
 # All rights reserved.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution.
 from __future__ import absolute_import, division, unicode_literals
-import doctest
 import os
 import unittest
 import collections
 
+import pytest
+
 import jsonpickle
 import jsonpickle.backend
 import jsonpickle.handlers
-
 from jsonpickle import compat, tags, util
 from jsonpickle.compat import PY2, PY3
-
 from helper import SkippableTest
 
 
@@ -1555,17 +1554,5 @@ def test_repeat_objects_are_expanded():
     assert flattened['passengers'][0]['child']['name'] == 'bob'
 
 
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(JSONPickleTestCase))
-    suite.addTest(unittest.makeSuite(PicklingTestCase))
-    suite.addTest(unittest.makeSuite(PicklingProtocol2TestCase))
-    suite.addTest(unittest.makeSuite(PicklingProtocol4TestCase))
-    suite.addTest(doctest.DocTestSuite(jsonpickle))
-    suite.addTest(doctest.DocTestSuite(jsonpickle.pickler))
-    suite.addTest(doctest.DocTestSuite(jsonpickle.unpickler))
-    return suite
-
-
 if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+    pytest.main([__file__])

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1529,6 +1529,15 @@ class PicklingProtocol2TestCase(SkippableTest):
         self.test_cyclical_objects_unpickleable_false(use_tuple=False)
 
 
+def test_dict_references_are_preserved():
+    data = {}
+    actual = jsonpickle.decode(jsonpickle.encode([data, data]))
+    assert isinstance(actual, list)
+    assert isinstance(actual[0], dict)
+    assert isinstance(actual[1], dict)
+    assert actual[0] is actual[1]
+
+
 def test_repeat_objects_are_expanded():
     """Ensure that all objects are present in the json output"""
     # When references are disabled we should create expanded copies


### PR DESCRIPTION
Register dictionaries as eligible for referencing.
Ensure that dictionary identity is preserved across a roundtrip.

Resolves #255