### PR TITLE
Small speedups for _flatten_impl and others

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -271,15 +271,14 @@ class Pickler(object):
         if PY2 and isinstance(obj, types.FileType):
             return self._flatten_file(obj)
 
-        if util.is_bytes(obj):
-            return self._flatten_bytestring(obj)
-
-        if util.is_primitive(obj):
-            return obj
-
         # Decimal is a primitive when use_decimal is True
-        if self._use_decimal and isinstance(obj, decimal.Decimal):
+        if type(obj) in util.PRIMITIVES or (
+            self._use_decimal and isinstance(obj, decimal.Decimal)
+        ):
             return obj
+
+        if type(obj) is bytes:
+            return self._flatten_bytestring(obj)
         #########################################
 
         self._push()
@@ -320,41 +319,38 @@ class Pickler(object):
         return [self._flatten(v) for v in obj]
 
     def _get_flattener(self, obj):
-
-        list_recurse = self._list_recurse
-
-        if util.is_list(obj):
+        if type(obj) is list:
             if self._mkref(obj):
-                return list_recurse
+                return self._list_recurse
             else:
                 self._push()
                 return self._getref
 
-        # We handle tuples and sets by encoding them in a "(tuple|set)dict"
-        if util.is_tuple(obj):
-            if not self.unpicklable:
-                return list_recurse
-            return lambda obj: {tags.TUPLE: [self._flatten(v) for v in obj]}
-
-        if util.is_set(obj):
-            if not self.unpicklable:
-                return list_recurse
-            return lambda obj: {tags.SET: [self._flatten(v) for v in obj]}
-
-        if util.is_dictionary(obj):
+        elif type(obj) is dict:
             if self._mkref(obj):
                 return self._flatten_dict_obj
             else:
                 self._push()
                 return self._getref
 
-        if util.is_type(obj):
-            return _mktyperef
+        # We handle tuples and sets by encoding them in a "(tuple|set)dict"
+        elif type(obj) is tuple:
+            if not self.unpicklable:
+                return self._list_recurse
+            return lambda obj: {tags.TUPLE: [self._flatten(v) for v in obj]}
 
-        if util.is_object(obj):
+        elif type(obj) is set:
+            if not self.unpicklable:
+                return self._list_recurse
+            return lambda obj: {tags.SET: [self._flatten(v) for v in obj]}
+
+        elif util.is_object(obj):
             return self._ref_obj_instance
 
-        if util.is_module_function(obj):
+        elif util.is_type(obj):
+            return _mktyperef
+
+        elif util.is_module_function(obj):
             return self._flatten_function
 
         # instance methods, lambdas, old style classes...

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -271,14 +271,14 @@ class Pickler(object):
         if PY2 and isinstance(obj, types.FileType):
             return self._flatten_file(obj)
 
+        if type(obj) is bytes:
+            return self._flatten_bytestring(obj)
+
         # Decimal is a primitive when use_decimal is True
         if type(obj) in util.PRIMITIVES or (
             self._use_decimal and isinstance(obj, decimal.Decimal)
         ):
             return obj
-
-        if type(obj) is bytes:
-            return self._flatten_bytestring(obj)
         #########################################
 
         self._push()

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -36,21 +36,27 @@ if PY2:
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = {list, set, tuple}
 PRIMITIVES = {compat.ustr, bool, type(None)} | set(numeric_types)
-NON_REDUCIBLE_TYPES = {
-    int,
-    float,
-    list,
-    dict,
-    set,
-    tuple,
-    object,
-    bytes,
+FUNCTION_TYPES = {
     types.FunctionType,
     types.MethodType,
     types.LambdaType,
     types.BuiltinFunctionType,
     types.BuiltinMethodType,
-} | PRIMITIVES
+}
+NON_REDUCIBLE_TYPES = (
+    {
+        int,
+        float,
+        list,
+        dict,
+        set,
+        tuple,
+        object,
+        bytes,
+    }
+    | PRIMITIVES
+    | FUNCTION_TYPES
+)
 
 
 def is_type(obj):
@@ -274,14 +280,7 @@ def is_function(obj):
     >>> is_function(1)
     False
     """
-    function_types = {
-        types.FunctionType,
-        types.MethodType,
-        types.LambdaType,
-        types.BuiltinFunctionType,
-        types.BuiltinMethodType,
-    }
-    return type(obj) in function_types
+    return type(obj) in FUNCTION_TYPES
 
 
 def is_module_function(obj):


### PR DESCRIPTION
Speeds up ``Pickler._flatten_impl``, ``Pickler._get_flattener``, and ``util._is_function``.

``_flatten_impl``:
- Condense type checks
- Remove function call

``_get_flattener``:
- Removed slow function alias
- Rearranged checks to check more common cases first

``is_function``:
- Avoided construction of a new set every call