### PR TITLE
Update python versions for tox targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ TOXCMD += --parallel $(NUM_JOBS)
 TOXCMD += --develop --skip-missing-interpreters
 ifdef multi
     TOXCMD += -e
-    TOXCMD += 'clean,py{27,36,37,38},py{27,37}-sa{10,11,12,13},py{27,37}-libs'
+    TOXCMD += 'clean,py{27,36,37,38,39},py{27,38}-sa{10,11,12,13},py{27,38}-libs'
 endif
 ifdef V
     TESTCMD += --verbose


### PR DESCRIPTION
Add python 3.9 as a target since it's now the current stable release, and increment the lib testing by one python version since we incremented the main testing versions by 1.