### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,7 +38,7 @@ Choosing and Loading Backends
 jsonpickle allows the user to specify what JSON backend to use
 when encoding and decoding. By default, jsonpickle will try to use, in
 the following order: :mod:`simplejson`, :mod:`json`, and :mod:`demjson`.
-The prefered backend can be set via :func:`jsonpickle.set_preferred_backend`.
+The preferred backend can be set via :func:`jsonpickle.set_preferred_backend`.
 Additional JSON backends can be used via :func:`jsonpickle.load_backend`.
 
 For example, users of `Django <http://www.djangoproject.com/>`_ can use the

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -43,7 +43,7 @@ To test against these libs on Python 3.7::
 
     tox -e py37-libs
 
-To create the enivornment without running tests::
+To create the environment without running tests::
 
     tox -e libs --notest
 

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -114,7 +114,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
             if size_threshold is None, values are always stored as nested lists
         :param compression: a compression module or None
             valid values for 'compression' are {zlib, bz2, None}
-            if compresion is None, no compression is applied
+            if compression is None, no compression is applied
         """
         self.size_threshold = size_threshold
         self.compression = compression
@@ -240,7 +240,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
             if size_threshold is None, values are always stored as nested lists
         :param compression: a compression module or None
             valid values for 'compression' are {zlib, bz2, None}
-            if compresion is None, no compression is applied
+            if compression is None, no compression is applied
         """
         super(NumpyNDArrayHandlerView, self).__init__(size_threshold, compression)
         self.mode = mode

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -22,7 +22,7 @@ class PandasProcessor(object):
             dataframes are always stored as csv strings
         :param compression: a compression module or None
             valid values for 'compression' are {zlib, bz2, None}
-            if compresion is None, no compression is applied
+            if compression is None, no compression is applied
         """
         self.size_threshold = size_threshold
         self.compression = compression

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -595,7 +595,7 @@ class Pickler(object):
                 if self._mkref(factory):
                     # We've never seen this object before so pickle it in-place.
                     # Create an instance from the factory and assume that the
-                    # resulting instance is a suitable examplar.
+                    # resulting instance is a suitable exemplar.
                     value = self._flatten_obj_instance(handlers.CloneFactory(factory()))
                 else:
                     # We've seen this object before.

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1133,7 +1133,7 @@ class PicklingProtocol4TestCase(unittest.TestCase):
     def test_pickle_newargs_ex(self):
         """
         Ensure we can pickle and unpickle an object whose class needs arguments
-        to __new__ and get back the same typle
+        to __new__ and get back the same type
         """
         instance = PicklableNamedTupleEx(**{'a': 'b', 'n': 2})
         encoded = jsonpickle.encode(instance)
@@ -1349,7 +1349,7 @@ class PicklingProtocol2TestCase(SkippableTest):
     def test_pickle_newargs(self):
         """
         Ensure we can pickle and unpickle an object whose class needs arguments
-        to __new__ and get back the same typle
+        to __new__ and get back the same type
         """
         instance = PicklableNamedTuple(('a', 'b'), (1, 2))
         encoded = jsonpickle.encode(instance)


### PR DESCRIPTION
There are small typos in:
- docs/api.rst
- docs/contrib.rst
- jsonpickle/ext/numpy.py
- jsonpickle/ext/pandas.py
- jsonpickle/pickler.py
- tests/jsonpickle_test.py

Fixes:
- Should read `compression` rather than `compresion`.
- Should read `type` rather than `typle`.
- Should read `preferred` rather than `prefered`.
- Should read `exemplar` rather than `examplar`.
- Should read `environment` rather than `enivornment`.

Closes #355