### PR TITLE
Replace sklearn with scikit-learn

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,8 @@ pytest-cov
 pytest-flake8
 pytest-benchmark
 pytest-benchmark[histogram]
+scikit-learn
 simplejson
-sklearn
 sqlalchemy
 ujson
 yajl; sys_platform != 'win32' and python_version < '3.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ testing =
 	numpy
 	pandas
 	pymongo
-	sklearn
+	scikit-learn
 	sqlalchemy
 
 testing.libs =


### PR DESCRIPTION
The sklearn package is a wrapper around scikit-learn, and sklearn will be removed at some point, starting with brownouts.

Instead, use scikit-learn directly.

See https://github.com/scikit-learn/scikit-learn/issues/8215 for more info.