### PR TITLE
Add ``v1_decode`` argument to ``jsonpickle.decode``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ v2.0.1
       and/or repr objects. (+354)
     * ``is_iterator()`` was sped up by ~20% by removing an unnecessary
       variable assignment. (+354)
+    * ``jsonpickle.decode`` has a new option, ``v1_decode`` to assist in
+      decoding objects created in jsonpickle version 1.(#364)
 
 v2.0.0
 ======

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -48,8 +48,9 @@ def decode(
 
     The keyword argument 'v1_decode' defaults to False.
     If set to True it enables you to decode objects serialized in jsonpickle v1.
-    Please do not attempt to re-encode the objects in the v1 format! Version 2's format
-    fixes issue #255, and allows dictionary identity to be preserved through an en/decode.
+    Please do not attempt to re-encode the objects in the v1 format! Version 2's
+    format fixes issue #255, and allows dictionary identity to be preserve through
+    an encode/decode cycle.
 
     >>> decode('"my string"') == 'my string'
     True

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -831,6 +831,10 @@ class JSONPickleTestCase(SkippableTest):
         self.assertEqual(decoded_middle_obj.attribute, middle_obj.attribute)
         self.assertEqual(decoded_inner_obj.attribute, inner_obj.attribute)
 
+    def test_v1_decode(self):
+        # TODO: Find a simple example that reproduces #364
+        self.assertTrue(True)
+
 
 class PicklableNamedTuple(object):
     """


### PR DESCRIPTION
This allows users to deserialize objects that were encoded with version 1, in version 2. Closes #364.