### PR TITLE
Remove DemJSON Test

### DIFF
--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 import decimal
+import sys
 import unittest
 from warnings import warn
 
@@ -30,6 +31,8 @@ class BackendBase(SkippableTest):
 
         self._is_installed(backend)
 
+        self.backend = backend
+
         jsonpickle.load_backend(*args)
         jsonpickle.set_preferred_backend(backend)
 
@@ -52,6 +55,8 @@ class BackendBase(SkippableTest):
         self.assertEqual(expect['things'][0].name, actual['things'][0].name)
         self.assertEqual(expect['things'][0].child, actual['things'][0].child)
 
+    @unittest.skipIf(self.backend=='demjson' and sys.version_info >= (3, 9),
+                     "DemJSON doesn't support Python 3.9+")
     def test_None_dict_key(self):
         """Ensure that backends produce the same result for None dict keys"""
         data = {None: None}

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -31,16 +31,11 @@ class BackendBase(SkippableTest):
 
         self._is_installed(backend)
 
-        self.backend = backend
-
         jsonpickle.load_backend(*args)
         jsonpickle.set_preferred_backend(backend)
 
     def set_preferred_backend(self, backend):
         self._is_installed(backend)
-
-        self.backend = backend
-
         jsonpickle.set_preferred_backend(backend)
 
     def tearDown(self):
@@ -60,14 +55,6 @@ class BackendBase(SkippableTest):
 
     def test_None_dict_key(self):
         """Ensure that backends produce the same result for None dict keys"""
-
-        if (
-            hasattr(self, 'backend')
-            and self.backend == 'demjson'
-            and sys.version_info >= (3, 9)
-        ):
-            self.skipTest("DemJSOB doesn't support CPython 3.9+")
-
         data = {None: None}
         expect = {'null': None}
         pickle = jsonpickle.encode(data)
@@ -148,28 +135,6 @@ def has_module(module):
         warn(module + ' module not available for testing, ' 'consider installing')
         return False
     return True
-
-
-class DemjsonTestCase(BackendBase):
-    def setUp(self):
-        self.set_preferred_backend('demjson')
-
-    def test_backend(self):
-        expected_pickled = compat.ustr(
-            '{"things":[{'
-            '"child":null,'
-            '"name":"data",'
-            '"py/object":"backend_test.Thing"}'
-            ']}'
-        )
-        self.assertEncodeDecode(expected_pickled)
-
-    def test_int_dict_keys_with_numeric_keys(self):
-        jsonpickle.set_encoder_options('demjson', strict=False)
-        int_dict = {1000: [1, 2]}
-        pickle = jsonpickle.encode(int_dict, numeric_keys=True)
-        actual = jsonpickle.decode(pickle)
-        self.assertEqual(actual[1000], [1, 2])
 
 
 class JsonlibTestCase(BackendBase):

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -27,11 +27,11 @@ class BackendBase(SkippableTest):
             return self.skip('%s not available; please install' % backend)
 
     def set_backend(self, *args):
-        global backend
-
         backend = args[0]
 
         self._is_installed(backend)
+
+        self.backend = backend
 
         jsonpickle.load_backend(*args)
         jsonpickle.set_preferred_backend(backend)
@@ -55,10 +55,12 @@ class BackendBase(SkippableTest):
         self.assertEqual(expect['things'][0].name, actual['things'][0].name)
         self.assertEqual(expect['things'][0].child, actual['things'][0].child)
 
-    @unittest.skipIf(backend=='demjson' and sys.version_info >= (3, 9),
-                     "DemJSON doesn't support Python 3.9+")
     def test_None_dict_key(self):
         """Ensure that backends produce the same result for None dict keys"""
+
+        if self.backend == 'demjson' and sys.version_info >= (3, 9):
+            self.skipTest("DemJSOB doesn't support CPython 3.9+")
+
         data = {None: None}
         expect = {'null': None}
         pickle = jsonpickle.encode(data)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -38,6 +38,9 @@ class BackendBase(SkippableTest):
 
     def set_preferred_backend(self, backend):
         self._is_installed(backend)
+
+        self.backend = backend
+
         jsonpickle.set_preferred_backend(backend)
 
     def tearDown(self):

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -27,11 +27,11 @@ class BackendBase(SkippableTest):
             return self.skip('%s not available; please install' % backend)
 
     def set_backend(self, *args):
+        global backend
+
         backend = args[0]
 
         self._is_installed(backend)
-
-        self.backend = backend
 
         jsonpickle.load_backend(*args)
         jsonpickle.set_preferred_backend(backend)
@@ -55,7 +55,7 @@ class BackendBase(SkippableTest):
         self.assertEqual(expect['things'][0].name, actual['things'][0].name)
         self.assertEqual(expect['things'][0].child, actual['things'][0].child)
 
-    @unittest.skipIf(self.backend=='demjson' and sys.version_info >= (3, 9),
+    @unittest.skipIf(backend=='demjson' and sys.version_info >= (3, 9),
                      "DemJSON doesn't support Python 3.9+")
     def test_None_dict_key(self):
         """Ensure that backends produce the same result for None dict keys"""

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, unicode_literals
 import decimal
-import sys
 import unittest
 from warnings import warn
 
 import jsonpickle
-from jsonpickle import compat
 from jsonpickle.compat import PY2
 from jsonpickle.compat import PY3
 
@@ -187,8 +185,6 @@ def suite():
     suite.addTest(unittest.makeSuite(JsonTestCase))
     suite.addTest(unittest.makeSuite(UJsonTestCase))
     suite.addTest(unittest.makeSuite(SimpleJsonTestCase))
-    if has_module('demjson'):
-        suite.addTest(unittest.makeSuite(DemjsonTestCase))
     if has_module('yajl'):
         suite.addTest(unittest.makeSuite(YajlTestCase))
     if PY2:

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -58,7 +58,11 @@ class BackendBase(SkippableTest):
     def test_None_dict_key(self):
         """Ensure that backends produce the same result for None dict keys"""
 
-        if self.backend == 'demjson' and sys.version_info >= (3, 9):
+        if (
+            hasattr(self, 'backend')
+            and self.backend == 'demjson'
+            and sys.version_info >= (3, 9)
+        ):
             self.skipTest("DemJSOB doesn't support CPython 3.9+")
 
         data = {None: None}


### PR DESCRIPTION
DemJSON doesn't support CPython 3.9+. It'd be worth considering dropping its backend, as DemJSON itself hasn't been updated since 2015.