### PR TITLE
Add 3.10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
         env:
           - TOXENV: libs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
         os: [ubuntu-20.04]
         env:
           - TOXENV: libs
-          - TOXENV: sa10
-          - TOXENV: sa11
           - TOXENV: sa12
           - TOXENV: sa13
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
     - script: |
         tox -- --junit-xml=test-results.xml
       env:
-        TOXENV: {libs,sa10,sa11,sa12,sa13}
+        TOXENV: {libs,sa12,sa13}
       displayName: 'run tests'
 
     - task: PublishTestResults@2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,6 @@ pytest-benchmark
 pytest-benchmark[histogram]
 scikit-learn
 simplejson
-sqlalchemy>=1.3.24
+sqlalchemy>=1.2.19
 ujson
 yajl; sys_platform != 'win32' and python_version < '3.0'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,6 @@ pytest-benchmark
 pytest-benchmark[histogram]
 scikit-learn
 simplejson
-sqlalchemy
+sqlalchemy>=1.3.24
 ujson
 yajl; sys_platform != 'win32' and python_version < '3.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,12 @@ classifiers =
 	Programming Language :: Python :: 2
 	Programming Language :: Python :: 2.7
 	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.5
+        Programming Language :: Python :: 3.6
+        Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Programming Language :: JavaScript
 	Operating System :: OS Independent
 	Topic :: Software Development :: Libraries :: Python Modules

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ requires =
 passenv =
     FORCE_COLOR
 deps =
-	sa10: sqlalchemy>=1.0,<1.1
-	sa11: sqlalchemy>=1.1,<1.2
 	sa12: sqlalchemy>=1.2,<1.3
 	sa13: sqlalchemy>=1.3,<1.4
 pip_version = pip


### PR DESCRIPTION
This will:
- Add CPython 3.10 to the test suite
- Clarify on PyPi which versions of CPython 3 are supported
- Remove testing of SQLAlchemy >=1.0,<1.2 in order to make tests pass with CPython 3.10