### PR TITLE
Auto-apply black changes to commits to main

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+permissions:
+   contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run black check
+        uses: psf/black@stable
+        with:
+          options: "--check --diff"
+
+      - name: Run black format
+        if: failure()
+        uses: psf/black@stable
+        with:
+          options: ""
+
+      - name: Commit black format
+        if: failure()
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Apply black to code"
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 22.3.0
   hooks:
   - id: black
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs=dist build .tox .eggs
-addopts=--doctest-modules --flake8 --black --cov
+addopts=--doctest-modules --flake8 --cov
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 filterwarnings=
     # https://github.com/pytest-dev/pytest/issues/6928

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ numpy
 pandas
 pymongo
 pytest
-pytest-black-multipy
 pytest-cov
 pytest-flake8 < 1.1.0; python_version <= '3.6'
 pytest-flake8 >= 1.1.1; python_version >= '3.7'


### PR DESCRIPTION
Also remove black from the pytest matrix, since github actions will automatically fix the code and pytest-black was causing 73 deprecation warnings, due to not being updated since October 5th, 2020.