### PR TITLE
Add gmpy.mpz handler for ecdsa

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -10,3 +10,12 @@ enable the numpy extension by registering its handlers::
 
     >>> import jsonpickle.ext.numpy as jsonpickle_numpy
     >>> jsonpickle_numpy.register_handlers()
+
+Ecdsa
+-----
+For the ecdsa module's keys, when trying to serialize them with
+``gmpy2`` installed, jsonpickle will error unless the ``gmpy``
+handlers are registered:
+
+    >>> import jsonpickle.ext.gmpy as jsonpickle_gmpy
+    >>> jsonpickle_gmpy.register_handlers()

--- a/jsonpickle/ext/gmpy.py
+++ b/jsonpickle/ext/gmpy.py
@@ -1,0 +1,22 @@
+import gmpy2 as gmpy
+
+from ..handlers import BaseHandler, register, unregister
+
+__all__ = ['register_handlers', 'unregister_handlers']
+
+
+class GmpyMPZHandler(BaseHandler):
+    def flatten(self, obj, data):
+        data['int'] = int(obj)
+        return data
+
+    def restore(self, data):
+        return gmpy.mpz(data['int'])
+
+
+def register_handlers():
+    register(gmpy.mpz, GmpyMPZHandler, base=True)
+
+
+def unregister_handlers():
+    unregister(gmpy.mpz)

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -48,7 +48,7 @@ def encode(
         instances. If you experience (de)serialization being incorrect when you
         use numpy, pandas, or sklearn handlers, this should be set to ``False``.
         If you want the output to not include the dtype for numpy arrays, add
-        ``jsonpickle.register(numpyp.generic,
+        ``jsonpickle.register(numpy.generic,
          UnpicklableNumpyGenericHandler, base=True)`` before your pickling code.
     :param max_depth: If set to a non-negative integer then jsonpickle will
         not recurse deeper than 'max_depth' steps into the object.  Anything

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ bson
 coverage<5
 ecdsa
 feedparser
+gmpy2
 numpy
 pandas
 pymongo

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ testing =
 	# local
 	ecdsa
 	feedparser
+	gmpy2
 	numpy
 	pandas
 	pymongo

--- a/tests/ecdsa_test.py
+++ b/tests/ecdsa_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 import unittest
 
+import pytest
 from helper import SkippableTest
 
 import jsonpickle

--- a/tests/ecdsa_test.py
+++ b/tests/ecdsa_test.py
@@ -8,6 +8,14 @@ from helper import SkippableTest
 import jsonpickle
 
 
+@pytest.fixture(scope='module', autouse=True)
+def gmpy_extension():
+    """Initialize the gmpy extension for this test module"""
+    jsonpickle.ext.gmpy.register_handlers()
+    yield  # control to the test function.
+    jsonpickle.ext.gmpy.unregister_handlers()
+
+
 class EcdsaTestCase(SkippableTest):
     def setUp(self):
         try:


### PR DESCRIPTION
Closes #328 
Closes #316 
This fixes ecdsa's key encoding when gmpy2 is installed. Also, nobody should be using gmpy (v1) anyway, it was last released in 2013.