### PR TITLE
Pickling a function returns None as the module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ v3.0.0
       into different classes. (#148) (+392)
     * Fix bug with deserializing `numpy.poly1d`. (#391)
     * Allow frozen dataclasses to be deserialized. (#240)
+    * Fixed a bug where pickling a function could return a ``None`` module. (#399)
 
 v2.2.0
 ======

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -515,6 +515,9 @@ def importable_name(cls):
     # Use the fully-qualified name if available (Python >= 3.3)
     name = getattr(cls, '__qualname__', cls.__name__)
     module = translate_module_name(cls.__module__)
+    if not module:
+        if hasattr(cls, '__self__'):
+            module = cls.__self__.__class__.__module__
     return '{}.{}'.format(module, name)
 
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import doctest
+import io
 import time
 import unittest
 
@@ -226,6 +227,13 @@ class UtilTestCase(unittest.TestCase):
         old_instance = MethodTestOldStyle()
         self.assertTrue(has_method(old_instance, 'bound_method'))
         self.assertFalse(has_method(MethodTestOldStyle, 'bound_method'))
+
+    def test_importable_name(self):
+        func_being_tested_obj = util.importable_name
+        io_method_obj = io.BytesIO(b'bytes').readline
+        self.assertEqual(util.importable_name(func_being_tested_obj), 'jsonpickle.util.importable_name')
+        self.assertEqual(util.importable_name(io_method_obj), '_io.BytesIO.readline')
+        self.assertEqual(util.importable_name(dict), 'builtins.dict')
 
 
 def suite():


### PR DESCRIPTION
Pickling the readline function of io.BytesIO returns a None module instead of _io

```
>>> jsonpickle.encode(BytesIO(b'bytes').readline)
'{"py/function": "None.BytesIO.readline"}'
```