### PR TITLE
Fix flake8 tests - closes #414

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ bson
 coverage<5
 ecdsa
 feedparser
+flake8 <5.0.0
 gmpy2
 numpy
 pandas


### PR DESCRIPTION
Require flake8<5.0.0 to fix styling tests

closes #414 