### PR TITLE
Warn if a custom pickling handler returns None

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -521,7 +521,11 @@ class Pickler(object):
         if handler is not None:
             if self.unpicklable:
                 data[tags.OBJECT] = class_name
-            return handler(self).flatten(obj, data)
+            result = handler(self).flatten(obj, data)
+            if result is None:
+                self._pickle_warning(obj)
+            return result
+
 
         reduce_val = None
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -563,6 +563,14 @@ class PicklingTestCase(unittest.TestCase):
             jsonpickle.decode(encoded, classes={"MyPropertiesSlots": MyPropertiesDict}),
         )
 
+    def test_warnings(self):
+        data = os.fdopen(os.pipe()[0])
+        with warnings.catch_warnings(record=True) as w:
+            jsonpickle.encode(data, warn=True)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "replaced with None" in str(w[-1].message)
+
 
 class JSONPickleTestCase(SkippableTest):
     def setUp(self):


### PR DESCRIPTION
The docstring for the encode function says
```
    :param warn: If set to True then jsonpickle will warn when it
        returns None for an object which it cannot pickle
        (e.g. file descriptors).
```

However, if you pass in a file descriptor when running python 3.8 or higher the `TextIOHandler` gets used. This means that no warning is raised because there’s no check if a handler has returned None.