### PR TITLE
Fix #431

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v3.0.2
+======
+    * Properly raise warning if a custom pickling handler returns None. (#433)
+    * Fix issue with serialization of certain sklearn objects breaking when
+      the numpy handler was enabled. (#431) (+434)
+
 v3.0.1
 ======
     * Remove accidental pin of setuptools to versions below 59. This allows

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -324,6 +324,9 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
         else:
             # decode array view, which references the data of another array
             base = self.context.restore(base, reset=False)
+            if not isinstance(base, np.ndarray):
+                # the object is probably a nested list
+                base = np.array(base)
             assert (
                 base.flags.forc
             ), "Current implementation assumes base is C or F contiguous"


### PR DESCRIPTION
This issue was caused by the numpy handler assuming that a certain object was always a numpy array, even though in some cases it wasn't. Add a check and coercion to validate the assumption.