### PR TITLE
Pandas Compatibility & Fix #436

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ v3.0.2
     * Properly raise warning if a custom pickling handler returns None. (#433)
     * Fix issue with serialization of certain sklearn objects breaking when
       the numpy handler was enabled. (#431) (+434)
+    * Allow custom backends to not implement _encoder_options (#436) (+446)
+    * Implement compatibility with pandas 2 (+446)
 
 v3.0.1
 ======

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -221,7 +221,7 @@ class Pickler(object):
         self.include_properties = include_properties
 
     def _determine_sort_keys(self):
-        for _, options in self.backend._encoder_options.values():
+        for _, options in getattr(self.backend, '_encoder_options', {}).values():
             if options.get("sort_keys", False):
                 # the user has set one of the backends to sort keys
                 return True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ feedparser
 flake8<5
 gmpy2
 numpy
-pandas<2
+pandas
 pymongo
 pytest
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ testing =
 	feedparser
 	gmpy2
 	numpy
-	pandas<2
+	pandas
 	pymongo
 	scikit-learn
 	sqlalchemy

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -62,7 +62,7 @@ def test_dataframe_roundtrip():
             'an_inf': np.array([np.inf] * 3),
             'a_str': np.str_('foo'),
             'a_unicode': np.unicode_('bar'),
-            'date': np.array([np.datetime64('2014-01-01')] * 3),
+            'date': np.array([np.datetime64('2014-01-01')] * 3, dtype="datetime64[s]"),
             'complex': np.complex_([1 - 2j, 2 - 1.2j, 3 - 1.3j]),
             # TODO: the following dtypes are not currently supported.
             # 'object': np.object_([{'a': 'b'}]*3),


### PR DESCRIPTION
This PR fixes errors with pandas 2 in tests and implements the recommendation given in #436 to allow custom backends to not implement _encoder_options.