### PR TITLE
Fix depth tracking with list/dict referencing

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -788,7 +788,6 @@ class Pickler(object):
                     self._list_recurse if type(obj) is list else self._flatten_dict_obj
                 )
             else:
-                self._push()
                 return self._getref
 
         # We handle tuples and sets by encoding them in a "(tuple|set)dict"


### PR DESCRIPTION
Currently, the Pickler's depth is incorrectly incremented when flattening lists/dicts that are referenced via `py/id`, and it is not decremented again:

```python
import jsonpickle

l = []
pickler = jsonpickle.Pickler()
print(pickler._depth) # -1

pickler.flatten([])
print(pickler._depth) # -1

pickler.flatten([l])
print(pickler._depth) # -1

pickler.flatten([l, l])
print(pickler._depth) # 0

pickler.flatten([l, l, l, l, l])
print(pickler._depth) # 3
```

With the changes in this PR, all print statements in the above code output the expected value of -1