### PR TITLE
readthedocs: specify build.os

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,9 @@
+version: 2
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 python:
-  version: 3
   extra_requirements:
     - docs
   pip_install: true


### PR DESCRIPTION
readthedocs deprecated build.image. We need to specify the OS used by the build these days.

Related-to: https://blog.readthedocs.com/use-build-os-config/