### PR TITLE
Fix #447: Decoding zoneinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.pytest_cache
 /.tox
 /.idea
+/.vscode
 __pycache__
 *.py[cod]
 *.egg-info

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v3.0.3
+======
+    * Fixed a bug where pickling some built-in classes (e.g. zoneinfo) 
+      could return a ``None`` module. (#447)
+
 v3.0.2
 ======
     * Properly raise warning if a custom pickling handler returns None. (#433)

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -517,7 +517,10 @@ def importable_name(cls):
     module = translate_module_name(cls.__module__)
     if not module:
         if hasattr(cls, '__self__'):
-            module = cls.__self__.__class__.__module__
+            if hasattr(cls.__self__, '__module__'):
+                module = cls.__self__.__module__
+            else:
+                module = cls.__self__.__class__.__module__
     return '{}.{}'.format(module, name)
 
 

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -8,6 +8,7 @@
 
 import datetime
 import time
+from zoneinfo import ZoneInfo
 import unittest
 
 import jsonpickle
@@ -166,6 +167,21 @@ class DateTimeSimpleTestCase(unittest.TestCase):
         json = jsonpickle.encode(test_obj)
         test_obj_decoded = jsonpickle.decode(json)
         self.assertEqual(test_obj_decoded.data['ts'], test_obj_decoded.data_ref['ts'])
+
+    def test_datetime_with_ZoneInfo(self):
+        """
+        jsonpickle should pickle a datetime object with time zone info
+        """
+        now = datetime.datetime.now()
+
+        SaoPaulo = ZoneInfo('America/Sao_Paulo')
+        USEastern = ZoneInfo('US/Eastern')
+
+        now_sp = now.replace(tzinfo=SaoPaulo)
+        now_us = now.replace(tzinfo=USEastern)
+
+        self._roundtrip(now_sp)
+        self._roundtrip(now_us)
 
 
 class DateTimeAdvancedTestCase(unittest.TestCase):

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -8,7 +8,7 @@
 
 import datetime
 import time
-from zoneinfo import ZoneInfo
+import sys
 import unittest
 
 import jsonpickle
@@ -168,10 +168,14 @@ class DateTimeSimpleTestCase(unittest.TestCase):
         test_obj_decoded = jsonpickle.decode(json)
         self.assertEqual(test_obj_decoded.data['ts'], test_obj_decoded.data_ref['ts'])
 
+    @unittest.skipIf(sys.version_info < (3, 9), "only tested for python >= 3.9")
     def test_datetime_with_ZoneInfo(self):
         """
         jsonpickle should pickle a datetime object with time zone info
         """
+        # if sys.version_info >= (3, 9):
+        from zoneinfo import ZoneInfo
+
         now = datetime.datetime.now()
 
         SaoPaulo = ZoneInfo('America/Sao_Paulo')

--- a/tests/zoneinfo_test.py
+++ b/tests/zoneinfo_test.py
@@ -1,0 +1,32 @@
+from zoneinfo import ZoneInfo
+
+import unittest
+
+import jsonpickle
+
+
+class ZoneInfoSimpleTestCase(unittest.TestCase):
+    def _roundtrip(self, obj):
+        """
+        pickle and then unpickle object, then assert the new object is the
+        same as the original.
+        """
+        pickled = jsonpickle.encode(obj)
+        unpickled = jsonpickle.decode(pickled)
+        self.assertEqual(obj, unpickled)
+
+    def test_zoneinfo(self):
+        """
+        jsonpickle should pickle a zoneinfo object
+        """
+        self._roundtrip(ZoneInfo("Australia/Queensland"))
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(ZoneInfoSimpleTestCase))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/tests/zoneinfo_test.py
+++ b/tests/zoneinfo_test.py
@@ -1,32 +1,32 @@
-from zoneinfo import ZoneInfo
+import sys
 
-import unittest
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
 
-import jsonpickle
+    import unittest
 
+    import jsonpickle
 
-class ZoneInfoSimpleTestCase(unittest.TestCase):
-    def _roundtrip(self, obj):
-        """
-        pickle and then unpickle object, then assert the new object is the
-        same as the original.
-        """
-        pickled = jsonpickle.encode(obj)
-        unpickled = jsonpickle.decode(pickled)
-        self.assertEqual(obj, unpickled)
+    class ZoneInfoSimpleTestCase(unittest.TestCase):
+        def _roundtrip(self, obj):
+            """
+            pickle and then unpickle object, then assert the new object is the
+            same as the original.
+            """
+            pickled = jsonpickle.encode(obj)
+            unpickled = jsonpickle.decode(pickled)
+            self.assertEqual(obj, unpickled)
 
-    def test_zoneinfo(self):
-        """
-        jsonpickle should pickle a zoneinfo object
-        """
-        self._roundtrip(ZoneInfo("Australia/Queensland"))
+        def test_zoneinfo(self):
+            """
+            jsonpickle should pickle a zoneinfo object
+            """
+            self._roundtrip(ZoneInfo("Australia/Queensland"))
 
+    def suite():
+        suite = unittest.TestSuite()
+        suite.addTest(unittest.makeSuite(ZoneInfoSimpleTestCase))
+        return suite
 
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(ZoneInfoSimpleTestCase))
-    return suite
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+    if __name__ == '__main__':
+        unittest.main(defaultTest='suite')


### PR DESCRIPTION
I think I have the fix for issue #447 regarding handling zoneinfo objects. I added a unit test as well, it all passed. 