### PR TITLE
sphinx and readthedocs refresh

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,8 +2,10 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3"
+
 python:
-  extra_requirements:
-    - docs
-  pip_install: true
+  install:
+    - path: .
+      extra_requirements:
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,64 +1,22 @@
-# -- General configuration -----------------------------------------------------
 import os
 import sys
 
 # Use the source tree.
 sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'jaraco.packaging.sphinx',
-    'rst.linker',
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
-
-# The suffix of source filenames.
-source_suffix = '.rst'
-
-# The master toctree document.
 master_doc = 'index'
+html_theme = 'furo'
 
-# General information about the project.
-copyright = u'2008-2011, John Paulett; 2009-2020, David Aguilar'
-
-# List of directories, relative to source directory, that shouldn't be searched
-# for source files.
-exclude_trees = []
-
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
-
-# -- Options for HTML output ---------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  Major themes that come with
-# Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'default'
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'jsonpickledoc'
-
-
-# -- Options for LaTeX output --------------------------------------------------
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass [howto/manual]).
-latex_documents = [
-    ('index', 'jsonpickle.tex', 'jsonpickle Documentation', 'David Aguilar', 'manual'),
-]
-
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3': None}
-
-
+# Link dates and other references in the changelog
+extensions += ['rst.linker']
 link_files = {
     '../CHANGES.rst': dict(
         using=dict(GH='https://github.com'),
@@ -72,7 +30,7 @@ link_files = {
                 url='{package_url}/pull/{pull}',
             ),
             dict(
-                pattern=r'^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n',
+                pattern=r'(?m:^((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n)',
                 with_scm='{text}\n{rev[timestamp]:%d %b %Y}\n',
             ),
             dict(
@@ -82,3 +40,15 @@ link_files = {
         ],
     )
 }
+
+# Be strict about any broken references
+nitpicky = True
+
+extensions += ['sphinx.ext.intersphinx']
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/stable/', None),
+}
+
+# Preserve authored syntax for defaults
+autodoc_preserve_defaults = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,6 @@ complex data structures to be serialized to JSON. jsonpickle is highly
 configurable and extendable--allowing the user to choose the JSON backend
 and add additional backends.
 
-.. contents::
-
 jsonpickle Usage
 ================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4.1"]
+requires = ["setuptools>=56", "setuptools_scm[toml]>=3.4.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,8 +71,9 @@ testing.libs =
 docs =
 	# upstream
 	sphinx
-	jaraco.packaging >= 3.2
+	jaraco.packaging >= 9.3
 	rst.linker >= 1.9
+	furo
 
 	# local
 


### PR DESCRIPTION
Update the readthedocs.org and sphinx configuration to
handle the readthedocs v2 configuration update.

Refresh the sphinx configuration to match the skeleton
configuration at https://github.com/jaraco/skeleton/