### PR TITLE
Avoid backward-compatibility timezone names

### DIFF
--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -179,10 +179,10 @@ class DateTimeSimpleTestCase(unittest.TestCase):
         now = datetime.datetime.now()
 
         SaoPaulo = ZoneInfo('America/Sao_Paulo')
-        USEastern = ZoneInfo('US/Eastern')
+        NewYork = ZoneInfo('America/New_York')
 
         now_sp = now.replace(tzinfo=SaoPaulo)
-        now_us = now.replace(tzinfo=USEastern)
+        now_us = now.replace(tzinfo=NewYork)
 
         self._roundtrip(now_sp)
         self._roundtrip(now_us)

--- a/tests/zoneinfo_test.py
+++ b/tests/zoneinfo_test.py
@@ -20,7 +20,7 @@ if sys.version_info >= (3, 9):
             """
             jsonpickle should pickle a zoneinfo object
             """
-            self._roundtrip(ZoneInfo("Australia/Queensland"))
+            self._roundtrip(ZoneInfo("Australia/Brisbane"))
 
     def suite():
         suite = unittest.TestSuite()


### PR DESCRIPTION
"US/Eastern" and "Australia/Queensland" are counted as backward-compatibility links, and are no longer shipped in all installations.  Use the corresponding canonical timezone names instead.