### PR TITLE
Fix #478

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,15 @@ v3.0.3
       could return a ``None`` module. (#447)
     * Fixed a bug where unpickling a missing class would return a different object
       instead of ``None``. (+471)
-    * Fixed the handling of missing classes when setting ``on_missing`` to ``warn`` or ``error``. (+471)
+    * Fixed the handling of missing classes when setting ``on_missing`` to ``warn``
+      or ``error``. (+471)
     * The test suite was made compatible with Python 3.12.
     * The tox configuration was updated to generate code coverage reports.
     * The suite now uses ``ruff`` to validate python code.
     * The documentation can now be built offline when ``rst.linker`` and
       ``jaraco.packaging.sphinx`` are not available.
+    * Fixed an issue with django.SafeString and other classes inheriting from
+      str having read-only attribute errors (#478) (+481)
 
 v3.0.2
 ======

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -626,11 +626,11 @@ class Unpickler(object):
                         # i think this is the only way to set frozen dataclass attrs
                         object.__setattr__(instance, k, value)
                     except AttributeError as e:
-                        # some objects may raise this for read-only attributes (#422)
+                        # some objects may raise this for read-only attributes (#422) (#478)
                         if (
                             hasattr(instance, "__slots__")
                             and not len(instance.__slots__)
-                            and issubclass(instance.__class__, int)
+                            and issubclass(instance.__class__, (int, str))
                         ):
                             continue
                         raise e


### PR DESCRIPTION
This issue was very similar to https://github.com/jsonpickle/jsonpickle/issues/422#issuecomment-1355438316. In that case, the issue was because the attribute is being inherited from a class implemented in C, which can make read-only attributes. The fix I implemented in that case was to skip it for subclasses of int, but since this is happening for subclasses of str too, this will add str to the list of parent classes that can be skipped. Eventually, I'll make a more flexible check that doesn't require us to whitelist types, but that's going to have to be on the TODO list for now.
Note: If this is merged, squash the commits instead of merging all of them.