### PR TITLE
tests: enable cache for pytest-ruff >= 0.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ v3.0.4
 ======
     * Fixed an issue with django.SafeString and other classes inheriting from
       str having read-only attribute errors (#478) (+481)
+    * `pytest-ruff` was pinned to the `0.2.x` versions to defer a breaking
+      change in `ruff>=0.3.0`.
 
 v3.0.3
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,7 @@ v3.0.4
 ======
     * Fixed an issue with django.SafeString and other classes inheriting from
       str having read-only attribute errors (#478) (+481)
-    * `pytest-ruff` was pinned to the `0.2.x` versions to defer a breaking
-      change in `ruff>=0.3.0`.
+    * The test suite was made compatible with `pytest-ruff>=0.3.0`. (+482)
 
 v3.0.3
 ======

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help::
 .PHONY: help
 
 test::
-	$(TESTCMD) $(flags)
+	$(TESTCMD) jsonpickle tests $(flags)
 .PHONY: test
 
 tox::

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ JOB_COUNT := $(shell printf '%s' "$(JOB_FLAGS)" | sed -e 's/-j//')
 DASH_J := $(shell echo -- $(JOB_FLAGS) -j$(nproc) | grep -o -e '-j[0-9]\+' | head -n 1)
 NUM_JOBS := $(shell printf %s "$(DASH_J)" | sed -e 's/-j//')
 
-TESTCMD ?= $(PYTEST) -p no:cacheprovier
+TESTCMD ?= $(PYTEST)
 BENCHMARKCMD ?= $(BENCHMARK)
 TOXCMD ?= $(TOX) run-parallel --parallel-live
 ifdef V

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ testing =
 	pytest-checkdocs >= 1.2.3
 	pytest-cov
 	pytest-enabler >= 1.0.1
-	pytest-ruff < 0.3
+	pytest-ruff >= 0.2.1
 
 	# local
 	ecdsa

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
         Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
 	Programming Language :: JavaScript
 	Operating System :: OS Independent
 	Topic :: Software Development :: Libraries :: Python Modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ testing =
 	pytest-checkdocs >= 1.2.3
 	pytest-cov
 	pytest-enabler >= 1.0.1
-	pytest-ruff != 0.3
+	pytest-ruff < 0.3
 
 	# local
 	ecdsa

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ allowlist_externals =
 passenv =
 	FORCE_COLOR
 commands =
-	python3 -m pytest -p no:cacheprovider --cov --cov-append --cov-report=term-missing jsonpickle tests {posargs}
+	python3 -m pytest --cov --cov-append --cov-report=term-missing jsonpickle tests {posargs}
 depends =
 	{py36,py37,py38,py39,py310,py311,py312}: clean
 	report: py36,py37,py38,py39,py310,py311,py312


### PR DESCRIPTION
Newer versions of pytest-ruff require a cache provider.
Remove the no:cacheprovider flags to get pytest-ruff working again.