### PR TITLE
Add de/encode feature-flag for readonly attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ v3.0.3
     * The suite now uses ``ruff`` to validate python code.
     * The documentation can now be built offline when ``rst.linker`` and
       ``jaraco.packaging.sphinx`` are not available.
+    * Fixed an issue with django.SafeString and other classes inheriting from
+      str having read-only attribute errors (#478) (+481)
 
 v3.0.2
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v3.0.4
+======
+    * Fixed an issue with django.SafeString and other classes inheriting from
+      str having read-only attribute errors (#478) (+481)
+
 v3.0.3
 ======
     * Compatibilty with Pandas and Cython 3.0 was added. (#460) (+477)
@@ -5,7 +10,8 @@ v3.0.3
       could return a ``None`` module. (#447)
     * Fixed a bug where unpickling a missing class would return a different object
       instead of ``None``. (+471)
-    * Fixed the handling of missing classes when setting ``on_missing`` to ``warn`` or ``error``. (+471)
+    * Fixed the handling of missing classes when setting ``on_missing`` to ``warn``
+      or ``error``. (+471)
     * The test suite was made compatible with Python 3.12.
     * The tox configuration was updated to generate code coverage reports.
     * The suite now uses ``ruff`` to validate python code.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,6 @@ v3.0.3
     * The suite now uses ``ruff`` to validate python code.
     * The documentation can now be built offline when ``rst.linker`` and
       ``jaraco.packaging.sphinx`` are not available.
-    * Fixed an issue with django.SafeString and other classes inheriting from
-      str having read-only attribute errors (#478) (+481)
 
 v3.0.2
 ======

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -823,9 +823,9 @@ class Pickler(object):
             if not self.unpicklable:
                 return self._list_recurse
             return lambda obj: {
-                tags.TUPLE
-                if type(obj) is tuple
-                else tags.SET: [self._flatten(v) for v in obj]
+                tags.TUPLE if type(obj) is tuple else tags.SET: [
+                    self._flatten(v) for v in obj
+                ]
             }
 
         elif util.is_module_function(obj):

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -626,11 +626,11 @@ class Unpickler(object):
                         # i think this is the only way to set frozen dataclass attrs
                         object.__setattr__(instance, k, value)
                     except AttributeError as e:
-                        # some objects may raise this for read-only attributes (#422)
+                        # some objects may raise this for read-only attributes (#422) (#478)
                         if (
                             hasattr(instance, "__slots__")
                             and not len(instance.__slots__)
-                            and issubclass(instance.__class__, int)
+                            and issubclass(instance.__class__, (int, str))
                         ):
                             continue
                         raise e

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -62,7 +62,7 @@ def decode(
     non-awaitable function, it will call said callback function with the class
     name (a string) as the only parameter. Strings passed to on_missing are
     lowercased automatically.
-    
+
     The keyword argument 'handle_readonly' defaults to False.
     If set to True, the Unpickler will handle objects encoded with
     'handle_readonly' properly. Do not set this flag for objects not encoded
@@ -303,7 +303,13 @@ def has_tag_dict(obj, tag):
 
 class Unpickler(object):
     def __init__(
-        self, backend=None, keys=False, safe=False, v1_decode=False, on_missing="ignore", handle_readonly=False,
+        self,
+        backend=None,
+        keys=False,
+        safe=False,
+        v1_decode=False,
+        on_missing="ignore",
+        handle_readonly=False,
     ):
         self.backend = backend or json
         self.keys = keys

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -397,6 +397,20 @@ def is_cython_function(obj):
     )
 
 
+def is_readonly(obj, attr, value):
+    # CPython 3.11+ has 0-cost try/except, please use up-to-date versions!
+    try:
+        setattr(obj, attr, value)
+        return False
+    except AttributeError as e:
+        # this is okay, it means the attribute couldn't be set
+        return True
+    except TypeError as e:
+        # this should only be happening when obj is a dict
+        # as these errors happen when attr isn't a str
+        return True
+
+
 def in_dict(obj, key, default=False):
     """
     Returns true if key exists in obj.__dict__; false if not in.

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -402,10 +402,10 @@ def is_readonly(obj, attr, value):
     try:
         setattr(obj, attr, value)
         return False
-    except AttributeError as e:
+    except AttributeError:
         # this is okay, it means the attribute couldn't be set
         return True
-    except TypeError as e:
+    except TypeError:
         # this should only be happening when obj is a dict
         # as these errors happen when attr isn't a str
         return True

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -163,6 +163,13 @@ class MyPropertiesDict:
             and list(self.other_object) == list(other.other_object)
         )
 
+# see issue #478
+class SafeData:
+    __slots__ = ()
+
+class SafeString(str, SafeData):
+    __slots__ = ()
+
 
 def on_missing_callback(class_name):
     # not actually a runtime problem but it doesn't matter
@@ -989,7 +996,16 @@ class JSONPickleTestCase(SkippableTest):
         pickler = jsonpickle.Pickler()
         pickler.flatten([liszt, liszt, liszt, liszt, liszt])
         self.assertEqual(pickler._depth, -1)
-
+    
+    def test_readonly_attrs(self):
+        s = SafeString("test")
+        pickled = jsonpickle.encode(s, handle_readonly=True)
+        pickled_json_dict = jsonpickle.backend.json.loads(pickled)
+        # make sure it's giving concise output by erroring if it includes
+        # a default method which is unnecessary
+        self.assertTrue("join" not in pickled_json_dict)
+        unpickled = jsonpickle.decode(pickled)
+        self.assertEqual(unpickled.__class__, SafeString)
 
 class PicklableNamedTuple(object):
     """

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1008,6 +1008,7 @@ class JSONPickleTestCase(SkippableTest):
         self.assertTrue("join" not in pickled_json_dict)
         unpickled = jsonpickle.decode(pickled)
         self.assertEqual(unpickled.__class__, SafeString)
+        self.assertEqual(unpickled, s)
 
 
 class PicklableNamedTuple(object):


### PR DESCRIPTION
This PR adds a feature-flag that can be set to True for graceful handling of read-only attributes, and which produces concise output. There are a few BS commits in the history because my local black version was out-of-date, and I had some issues doing merges as I'm still trying to get used to git-cola.

In the future, I'm going to update the documentation for decode and other such functions to be more similar to encode, because I noticed some formatting differences that are bugging me.