### PR TITLE
Slightly Slim Down README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,12 +124,6 @@ GPG Signing
 ===========
 Unfortunately, while versions of jsonpickle before 3.0.1 should still be signed, GPG signing support was removed from PyPi (https://blog.pypi.org/posts/2023-05-23-removing-pgp/) back in May 2023.
 
-jsonpickleJS
-============
-`jsonpickleJS <https://github.com/cuthbertLab/jsonpickleJS>`_
-is a javascript implementation of jsonpickle by Michael Scott Cuthbert.
-jsonpickleJS can be extremely useful for projects that have parallel data
-structures between Python and Javascript.
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -124,8 +124,6 @@ GPG Signing
 ===========
 Unfortunately, while versions of jsonpickle before 3.0.1 should still be signed, GPG signing support was removed from PyPi (https://blog.pypi.org/posts/2023-05-23-removing-pgp/) back in May 2023.
 
-
 License
 =======
 Licensed under the BSD License. See COPYING for details.
-See jsonpickleJS/LICENSE for details about the jsonpickleJS license.

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@
 jsonpickle
 ==========
 jsonpickle is a library for the two-way conversion of complex Python objects
-and `JSON <http://json.org/>`_.  jsonpickle builds upon the existing JSON
+and `JSON <http://json.org/>`_.  jsonpickle builds upon existing JSON
 encoders, such as simplejson, json, and ujson.
 
 .. warning::
@@ -81,9 +81,9 @@ Install from github for the latest changes:
 
 Numpy/Pandas Support
 =============
-jsonpickle includes built-in numpy and pandas extensions.  If would like to
-encode sklearn models, numpy arrays, pandas DataFrames, and other
-numpy/pandas-based data then you must enable the numpy and/or pandas
+jsonpickle includes built-in numpy and pandas extensions.  If you would
+like to encode sklearn models, numpy arrays, pandas DataFrames, and other
+numpy/pandas-based data, then you must enable the numpy and/or pandas
 extensions by registering their handlers::
 
     >>> import jsonpickle.ext.numpy as jsonpickle_numpy

--- a/README.rst
+++ b/README.rst
@@ -87,22 +87,16 @@ If you have the files checked out for development:
     python setup.py develop
 
 
-Numpy Support
+Numpy/Pandas Support
 =============
-jsonpickle includes a built-in numpy extension.  If would like to encode
-sklearn models, numpy arrays, and other numpy-based data then you must
-enable the numpy extension by registering its handlers::
+jsonpickle includes built-in numpy and pandas extensions.  If would like to
+encode sklearn models, numpy arrays, pandas DataFrames, and other
+numpy/pandas-based data then you must enable the numpy and/or pandas
+extensions by registering their handlers::
 
     >>> import jsonpickle.ext.numpy as jsonpickle_numpy
-    >>> jsonpickle_numpy.register_handlers()
-
-Pandas Support
-==============
-jsonpickle includes a built-in pandas extension.  If would like to encode
-pandas DataFrame or Series objects then you must enable the pandas extension
-by registering its handlers::
-
     >>> import jsonpickle.ext.pandas as jsonpickle_pandas
+    >>> jsonpickle_numpy.register_handlers()
     >>> jsonpickle_pandas.register_handlers()
 
 Development

--- a/README.rst
+++ b/README.rst
@@ -78,14 +78,6 @@ Install from github for the latest changes:
 
     pip install git+https://github.com/jsonpickle/jsonpickle.git
 
-If you have the files checked out for development:
-
-::
-
-    git clone https://github.com/jsonpickle/jsonpickle.git
-    cd jsonpickle
-    python setup.py develop
-
 
 Numpy/Pandas Support
 =============


### PR DESCRIPTION
This PR removes and combines some old/outdated parts of the README. For example, it removed the jsonpickleJS section, since the JS version hasn't been updated in 10 years (it's probably very broken right now). It also combines the numpy/pandas sections, since those had a decent bit of duplicated text. Lastly, it removes the section detailing how to install jsonpickle if you have the files locally checked out, since it used a deprecated "setup.py develop" install method, which python warns about on 3.11. This last change might be better with a replacement such as "pip install ." when cd-ed into the directory, but I decided against that because I don't believe that works on Windows.

This is a first step towards getting the README in a readable manner in order to implement #484 in a clean way.