### PR TITLE
garden: add a garden file for jsonpickle.github.io update tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /env*
 /htmlcov
 /tags
+/pages
 /.pytest_cache
 /.tox
 /.idea

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ v3.0.4
     * Fixed an issue with django.SafeString and other classes inheriting from
       str having read-only attribute errors (#478) (+481)
     * The test suite was made compatible with `pytest-ruff>=0.3.0`. (+482)
+    * A `garden.yaml` file was added for use with the
+      `garden <https://crates.io/crates/garden-tools>_` command runner. (+486)
 
 v3.0.3
 ======

--- a/garden.yaml
+++ b/garden.yaml
@@ -1,0 +1,22 @@
+# Use "cargo install garden-tools" to install garden https://gitlab.com/garden-rs/garden
+#
+#   # Usage
+#   garden doc                  # Build the jsonpickle.github.io documentation
+trees:
+    jsonpickle:
+        description: Two-way conversion of complex Python objects into JSON.
+        path: ${GARDEN_CONFIG_DIR}
+        url: git@github.com:jsonpickle/jsonpickle.git
+        remotes:
+            Theelx: git@github.com:Theelx/jsonpickle.git
+            davvid: git@github.com:davvid/jsonpickle.git
+        commands:
+            doc: |
+                test -d pages || garden grow pages
+                python3 -m sphinx docs pages
+    pages:
+        description: The jsonpickle.github.io website.
+        url: git@github.com:jsonpickle/jsonpickle.github.io.git
+
+variables:
+    timestamp: $ date +%Y-%m-%dT%T%z

--- a/garden.yaml
+++ b/garden.yaml
@@ -11,9 +11,18 @@ trees:
             Theelx: git@github.com:Theelx/jsonpickle.git
             davvid: git@github.com:davvid/jsonpickle.git
         commands:
+            bench: |
+                python3 -m pytest \
+                    --benchmark-verbose \
+                    --benchmark-only \
+                    --benchmark-histogram=./images/benchmark-${timestamp} \
+                    ./jsonpickle_benchmarks.py
             doc: |
                 test -d pages || garden grow pages
                 python3 -m sphinx docs pages
+            fmt: black --skip-string-normalization --target-version py310 jsonpickle tests
+            test: python3 -m pytest ${GARDEN_CMD_VERBOSE} jsonpickle tests "$@"
+            tox: tox run-parallel --parallel-live "$@" ${GARDEN_CMD_VERBOSE}
     pages:
         description: The jsonpickle.github.io website.
         url: git@github.com:jsonpickle/jsonpickle.github.io.git


### PR DESCRIPTION
Add a garden file for use with [garden](https://crates.io/crates/garden-tools), a simple yet powerful command runner and git powertool.

Running `garden doc` will clone the github pages project and build the documentation into the pages repository.

Related-to: #484