### PR TITLE
Adjust documentation formatting

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -55,10 +55,6 @@ def encode(
             )
 
         before your pickling code.
-    :param max_depth: If set to a non-negative integer then jsonpickle will
-        not recurse deeper than 'max_depth' steps into the object.  Anything
-        deeper than 'max_depth' is represented using a Python repr() of the
-        object.
     :param make_refs: If set to False jsonpickle's referencing support is
         disabled.  Objects that are id()-identical won't be preserved across
         encode()/decode(), but the resulting JSON stream will be conceptually
@@ -68,12 +64,12 @@ def encode(
         dictionary keys instead of coercing them into strings via `repr()`.
         This is typically what you want if you need to support Integer or
         objects as dictionary keys.
-    :param numeric_keys: Only use this option if the backend supports integer
-        dict keys natively.  This flag tells jsonpickle to leave numeric keys
-        as-is rather than conforming them to json-friendly strings.
-        Using ``keys=True`` is the typical solution for integer keys, so only
-        use this if you have a specific use case where you want to allow the
-        backend to handle serialization of numeric dict keys.
+    :param max_depth: If set to a non-negative integer then jsonpickle will
+        not recurse deeper than 'max_depth' steps into the object.  Anything
+        deeper than 'max_depth' is represented using a Python repr() of the
+        object.
+    :param backend: If set to an instance of jsonpickle.backend.JSONBackend,
+        jsonpickle will use that backend for deserialization.
     :param warn: If set to True then jsonpickle will warn when it
         returns None for an object which it cannot pickle
         (e.g. file descriptors).
@@ -92,6 +88,12 @@ def encode(
 
         NOTE: A side-effect of the above settings is that float values will be
         converted to Decimal when converting to json.
+    :param numeric_keys: Only use this option if the backend supports integer
+        dict keys natively.  This flag tells jsonpickle to leave numeric keys
+        as-is rather than conforming them to json-friendly strings.
+        Using ``keys=True`` is the typical solution for integer keys, so only
+        use this if you have a specific use case where you want to allow the
+        backend to handle serialization of numeric dict keys.
     :param use_base85:
         If possible, use base85 to encode binary data. Base85 bloats binary data
         by 1/4 as opposed to base64, which expands it by 1/3. This argument is

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -68,11 +68,21 @@ def encode(
         not recurse deeper than 'max_depth' steps into the object.  Anything
         deeper than 'max_depth' is represented using a Python repr() of the
         object.
+    :param reset: Custom pickle handlers that use the `Pickler.flatten` method or
+        `jsonpickle.encode` function must call `encode` with `reset=False`
+        in order to retain object references during pickling.
+        This flag is not typically used outside of a custom handler or
+        `__getstate__` implementation.
     :param backend: If set to an instance of jsonpickle.backend.JSONBackend,
         jsonpickle will use that backend for deserialization.
     :param warn: If set to True then jsonpickle will warn when it
         returns None for an object which it cannot pickle
         (e.g. file descriptors).
+    :param context: Supply a pre-built Pickler or Unpickler object to the
+        `jsonpickle.encode` and `jsonpickle.decode` machinery instead
+        of creating a new instance. The `context` represents the currently
+        active Pickler and Unpickler objects when custom handlers are
+        invoked by jsonpickle.
     :param max_iter: If set to a non-negative integer then jsonpickle will
         consume at most `max_iter` items when pickling iterators.
     :param use_decimal: If set to True jsonpickle will allow Decimal

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -32,8 +32,20 @@ def decode(
     :param backend: If set to an instance of jsonpickle.backend.JSONBackend, jsonpickle
         will use that backend for deserialization.
 
+    :param context: Supply a pre-built Pickler or Unpickler object to the
+        `jsonpickle.encode` and `jsonpickle.decode` machinery instead
+        of creating a new instance. The `context` represents the currently
+        active Pickler and Unpickler objects when custom handlers are
+        invoked by jsonpickle.
+
     :param keys: If set to True then jsonpickle will decode non-string dictionary keys
         into python objects via the jsonpickle protocol.
+
+    :param reset: Custom pickle handlers that use the `Pickler.flatten` method or
+        `jsonpickle.encode` function must call `encode` with `reset=False`
+        in order to retain object references during pickling.
+        This flag is not typically used outside of a custom handler or
+        `__getstate__` implementation.
 
     :param safe: If set to True, eval() is avoided, but backwards-compatible
         (pre-0.7.0) deserialization of repr-serialized objects is disabled.

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -29,44 +29,37 @@ def decode(
 ):
     """Convert a JSON string into a Python object.
 
-    The keyword argument 'keys' defaults to False.
-    If set to True then jsonpickle will decode non-string dictionary keys
-    into python objects via the jsonpickle protocol.
+    :param backend: If set to an instance of jsonpickle.backend.JSONBackend, jsonpickle
+        will use that backend for deserialization.
 
-    The keyword argument 'classes' defaults to None.
-    If set to a single class, or a sequence (list, set, tuple) of classes,
-    then the classes will be made available when constructing objects.
-    If set to a dictionary of class names to class objects, the class object
-    will be provided to jsonpickle to deserialize the class name into.
-    This can be used to give jsonpickle access to local classes that are not
-    available through the global module import scope, and the dict method can
-    be used to deserialize encoded objects into a new class.
+    :param keys: If set to True then jsonpickle will decode non-string dictionary keys
+        into python objects via the jsonpickle protocol.
 
-    The keyword argument 'safe' defaults to False.
-    If set to True, eval() is avoided, but backwards-compatible
-    (pre-0.7.0) deserialization of repr-serialized objects is disabled.
+    :param safe: If set to True, eval() is avoided, but backwards-compatible
+        (pre-0.7.0) deserialization of repr-serialized objects is disabled.
 
-    The keyword argument 'backend' defaults to None.
-    If set to an instance of jsonpickle.backend.JSONBackend, jsonpickle
-    will use that backend for deserialization.
+    :param classes: If set to a single class, or a sequence (list, set, tuple) of classes,
+        then the classes will be made available when constructing objects.
+        If set to a dictionary of class names to class objects, the class object
+        will be provided to jsonpickle to deserialize the class name into.
+        This can be used to give jsonpickle access to local classes that are not
+        available through the global module import scope, and the dict method can
+        be used to deserialize encoded objects into a new class.
 
-    The keyword argument 'v1_decode' defaults to False.
-    If set to True it enables you to decode objects serialized in jsonpickle v1.
-    Please do not attempt to re-encode the objects in the v1 format! Version 2's
-    format fixes issue #255, and allows dictionary identity to be preserved
-    through an encode/decode cycle.
+    :param v1_decode: If set to True it enables you to decode objects serialized in jsonpickle v1.
+        Please do not attempt to re-encode the objects in the v1 format! Version 2's
+        format fixes issue #255, and allows dictionary identity to be preserved
+        through an encode/decode cycle.
 
-    The keyword argument 'on_missing' defaults to 'ignore'.
-    If set to 'error', it will raise an error if the class it's decoding is not
-    found. If set to 'warn', it will warn you in said case. If set to a
-    non-awaitable function, it will call said callback function with the class
-    name (a string) as the only parameter. Strings passed to on_missing are
-    lowercased automatically.
+    :param on_missing: If set to 'error', it will raise an error if the class it's decoding is not
+        found. If set to 'warn', it will warn you in said case. If set to a
+        non-awaitable function, it will call said callback function with the class
+        name (a string) as the only parameter. Strings passed to on_missing are
+        lowercased automatically.
 
-    The keyword argument 'handle_readonly' defaults to False.
-    If set to True, the Unpickler will handle objects encoded with
-    'handle_readonly' properly. Do not set this flag for objects not encoded
-    with 'handle_readonly' set to True.
+    :param handle_readonly: If set to True, the Unpickler will handle objects encoded with
+        'handle_readonly' properly. Do not set this flag for objects not encoded
+        with 'handle_readonly' set to True.
 
 
     >>> decode('"my string"') == 'my string'


### PR DESCRIPTION
This PR adds parameter tags to the decode part of the docs, and orders the encode docs to reflect the ordering of the input. Davvid, can you write a short description of what the `reset` and `context` args do, and I can add that to this PR?