### PR TITLE
sqlalchemy: update sqlalchemy.orm.declarative_base usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ v3.0.4
     * The test suite was made compatible with `pytest-ruff>=0.3.0`. (+482)
     * A `garden.yaml` file was added for use with the
       `garden <https://crates.io/crates/garden-tools>_` command runner. (+486)
+    * The test suite was updated to avoid deprecated SQLALchemy APIs.
 
 v3.0.3
 ======

--- a/tests/sqlalchemy_test.py
+++ b/tests/sqlalchemy_test.py
@@ -8,6 +8,7 @@ import jsonpickle
 
 try:
     import sqlalchemy as sqa
+    from sqlalchemy import orm
     from sqlalchemy.ext import declarative
     from sqlalchemy.orm import Session
 
@@ -16,7 +17,12 @@ except ImportError:
     HAS_SQA = False
 
 if HAS_SQA:
-    Base = declarative.declarative_base()
+    # sqlalchemy.ext.declarative.declarative_base() was deprecated in SQLAlchemy 2.0
+    # and replaced by sqlalchemy.orm.declarative_base().
+    if hasattr(orm, 'declarative_base'):
+        Base = orm.declarative_base()
+    else:
+        Base = declarative.declarative_base()
 
     class Table(Base):
         __tablename__ = 'table'


### PR DESCRIPTION
SQLAlchemy 2.0 deprecated sqlalchemy.ext.declarative.declarative_base(). The declarative_base() creator function was moved to sqlalchemy.orm.