### PR TITLE
Clarify dev requirement installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,10 @@ to activate the virtualenv without polluting the shell environment::
         vx env3 pip install --editable '.[dev]'
         vx env3 make test
 
+If you can't use a venv, you can install the testing packages as follows::
+
+        pip install .[testing]
+
 `jsonpickle` supports multiple Python versions, so using a combination of
 multiple virtualenvs and `tox` is useful in order to catch compatibility
 issues when developing.


### PR DESCRIPTION
This PR adds an alternative way to install dev requirements without a venv in light of the recent changes in https://github.com/jsonpickle/jsonpickle/commit/4bddb821e48768d8cde3c3f06c1dea9d2d68d543. It should be fairly straightforward, assuming people are ``cd``ed into the jsonpickle directory..