### PR TITLE
classes should support replacing with dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@ v3.1.0
 ======
     * `jsonpickle.ext.numpy.register_handlers` now provides options that are forwarded
       to the `NumpyNDArrayHandler` constructor. (+489)
+    * Fix bug of not handling ``classes`` argument to `jsonpickle.decode`
+      being a dict. Previously, the keys were ignored and only values were
+      used. (+494)
 
 v3.0.4
 ======

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -390,8 +390,8 @@ class Unpickler(object):
             for cls in classes:
                 self.register_classes(cls)
         elif isinstance(classes, dict):
-            for cls in classes.values():
-                self.register_classes(cls)
+            for cls in classes:
+                self._classes[cls] = classes[cls]
         else:
             self._classes[util.importable_name(classes)] = classes
 

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -390,8 +390,7 @@ class Unpickler(object):
             for cls in classes:
                 self.register_classes(cls)
         elif isinstance(classes, dict):
-            for cls in classes:
-                self._classes[cls] = classes[cls]
+            self._classes.update(classes)
         else:
             self._classes[util.importable_name(classes)] = classes
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -571,10 +571,9 @@ class PicklingTestCase(unittest.TestCase):
         obj = MyPropertiesSlots()
         encoded = jsonpickle.encode(obj)
         # MyPropertiesSlots and MyPropertiesDict have compatible eq methods
-        self.assertEqual(
-            obj,
-            jsonpickle.decode(encoded, classes={"MyPropertiesSlots": MyPropertiesDict}),
-        )
+        decoded = jsonpickle.decode(encoded, classes={"MyPropertiesSlots": MyPropertiesDict})
+        self.assertIsInstance(decoded, MyPropertiesDict)
+        self.assertEqual(obj, decoded)
 
     def test_warnings(self):
         data = os.fdopen(os.pipe()[0])


### PR DESCRIPTION
Without this change, passing a dict in `.decode()` will completely
ignore the key, and just substitute the value directly.

Consider the serialized data (`json_str`):
```
{
  "x": "value",
  "py/object": "older.pkg.Class",
}
```

If `Class` is now moved to `newer.pkg`, I'd expect to use the API like:

```
jsonpickle.decode(json_str, classes={"older.pkg.Class": newer.pkg.Class})
```

Currently the above API doesn't work, it will populate `self._classes` as:
```
{"newer.pkg.Class": new.pkg.Class}
```

The `"older.pkg.Class"` is completely ignored, even though `loadclass` is
implemented to support this case of class replacement. 