### PR TITLE
Fix reference tracking when using nested dictionaries/objects under `py/state`

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -607,23 +607,26 @@ class Unpickler(object):
 
         return restore_key
 
-    def _restore_from_dict(self, obj, instance, ignorereserved=True):
+    def _restore_from_dict(self, obj, instance, restore_dict_items=True):
         restore_key = self._restore_key_fn()
         method = _obj_setattr
         deferred = {}
 
         for k, v in util.items(obj):
             # ignore the reserved attribute
-            if ignorereserved and k in tags.RESERVED:
+            if restore_dict_items and k in tags.RESERVED:
                 continue
             if isinstance(k, numeric_types):
                 str_k = k.__str__()
             else:
                 str_k = k
             self._namestack.append(str_k)
-            k = restore_key(k)
-            # step into the namespace
-            value = self._restore(v)
+            if restore_dict_items:
+                k = restore_key(k)
+                # step into the namespace
+                value = self._restore(v)
+            else:
+                value = v
             if util.is_noncomplex(instance) or util.is_dictionary_subclass(instance):
                 try:
                     if k == '__dict__':
@@ -690,12 +693,12 @@ class Unpickler(object):
             # implements described default handling
             # of state for object with instance dict
             # and no slots
-            instance = self._restore_from_dict(state, instance, ignorereserved=False)
+            instance = self._restore_from_dict(state, instance, restore_dict_items=False)
         elif has_slots:
-            instance = self._restore_from_dict(state[1], instance, ignorereserved=False)
+            instance = self._restore_from_dict(state[1], instance, restore_dict_items=False)
             if has_slots_and_dict:
                 instance = self._restore_from_dict(
-                    state[0], instance, ignorereserved=False
+                    state[0], instance, restore_dict_items=False
                 )
         elif not hasattr(instance, '__getnewargs__') and not hasattr(
             instance, '__getnewargs_ex__'

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1102,6 +1102,9 @@ class PickleProtocol2GetStateDict(PickleProtocol2Thing):
     def __getstate__(self):
         return {'magic': True}
 
+class PickleProtocol2GetStateNestedDict(PickleProtocol2Thing):
+    def __getstate__(self):
+        return {'nested': {'magic': True}}
 
 class PickleProtocol2GetStateSlots(PickleProtocol2Thing):
     def __getstate__(self):
@@ -1554,6 +1557,20 @@ class PicklingProtocol2TestCase(SkippableTest):
         encoded = jsonpickle.encode(instance)
         decoded = jsonpickle.decode(encoded)
         self.assertTrue(decoded.magic)
+
+    def test_restore_nested_dict_state_with_references_preserved(self):
+        """
+        Ensure that nested dicts in "py/state" are not duplicated when tracking
+        objects to preserve references
+        """
+        instance1 = PickleProtocol2GetStateNestedDict('whatevs')
+        instance2 = PickleProtocol2GetStateNestedDict('different')
+        encoded = jsonpickle.encode([instance1, instance1, instance2, instance2])
+        decoded = jsonpickle.decode(encoded)
+        self.assertTrue(decoded[0].nested['magic'])
+        self.assertIs(decoded[1], decoded[0])
+        self.assertTrue(decoded[2].nested['magic'])
+        self.assertIs(decoded[3], decoded[2])
 
     def test_restore_slots_state(self):
         """


### PR DESCRIPTION
Fixes #500

This PR causes a dict returned from `__getstate__` (and stored in `py/state`) to no longer be restored twice, which previously caused any objects in it to be incorrectly duplicated in the Unpickler's list of object instances.