### PR TITLE
fix: pass mylocals to eval() for Python 3.13

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ v3.1.0
       class name strings as keys. (+494)
     * The ``garden setup/dev`` action and ``requirements-dev.txt`` requirements file
       now include test dependencies for use during development.
+    * Added support for Python 3.13. (+505)
 
 v3.0.4
 ======

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -286,7 +286,7 @@ def loadrepr(reprstr):
     if '.' in localname:
         localname = module.split('.', 1)[0]
     mylocals[localname] = __import__(module)
-    return eval(evalstr)
+    return eval(evalstr, mylocals)
 
 
 def has_tag_dict(obj, tag):

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 	Programming Language :: Python :: 3.12
+	Programming Language :: Python :: 3.13
 	Programming Language :: JavaScript
 	Operating System :: OS Independent
 	Topic :: Software Development :: Libraries :: Python Modules

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0
-envlist = clean,py36,py37,py38,py39,py310,py311,py312,report
+envlist = clean,py36,py37,py38,py39,py310,py311,py312,py313,report
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,8 +11,8 @@ passenv =
 commands =
 	python3 -m pytest --cov --cov-append --cov-report=term-missing jsonpickle tests {posargs}
 depends =
-	{py36,py37,py38,py39,py310,py311,py312}: clean
-	report: py36,py37,py38,py39,py310,py311,py312
+	{py36,py37,py38,py39,py310,py311,py312,py313}: clean
+	report: py36,py37,py38,py39,py310,py311,py312,py313
 extras =
 	testing
 pip_version = pip


### PR DESCRIPTION
Newer versions of python need mylocals to be specified in loadrepr().

Fixes: #504