### PR TITLE
Add support for (de)serializing NoneType correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v3.2.2
+======
+    * A bug with the incorrect (de)serialization of NoneType objects has been fixed.
+      (+507)
+
 v3.2.1
 ======
     * The ``ignorereserved`` parameter to the private ``_restore_from_dict()``

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -183,6 +183,9 @@ def loadclass(module_and_name, classes=None):
     0
 
     """
+    # NoneType is a special case and can not be imported/created
+    if module_and_name == "builtins.NoneType":
+        return type(None)
     # Check if the class exists in a caller-provided scope
     if classes:
         try:

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -183,9 +183,6 @@ def loadclass(module_and_name, classes=None):
     0
 
     """
-    # NoneType is a special case and can not be imported/created
-    if module_and_name == "builtins.NoneType":
-        return type(None)
     # Check if the class exists in a caller-provided scope
     if classes:
         try:
@@ -211,6 +208,9 @@ def loadclass(module_and_name, classes=None):
             return obj
         except (AttributeError, ImportError, ValueError):
             continue
+    # NoneType is a special case and can not be imported/created
+    if module_and_name == "builtins.NoneType":
+        return type(None)
     return None
 
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -257,6 +257,12 @@ class PicklingTestCase(unittest.TestCase):
         self.assertEqual(listD, self.pickler.flatten(listD))
         self.assertEqual(listD, self.unpickler.restore(listD))
 
+    def test_NoneType(self):
+        typ = type(None)
+        typ_pickled = jsonpickle.encode(typ)
+        typ_unpickled = jsonpickle.decode(typ_pickled)
+        self.assertEqual(typ, typ_unpickled)
+
     def test_set(self):
         setlist = ['orange', 'apple', 'grape']
         setA = set(setlist)

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -257,7 +257,7 @@ class PicklingTestCase(unittest.TestCase):
         self.assertEqual(listD, self.pickler.flatten(listD))
         self.assertEqual(listD, self.unpickler.restore(listD))
 
-    def test_NoneType(self):
+    def test_nonetype(self):
         typ = type(None)
         typ_pickled = jsonpickle.encode(typ)
         typ_unpickled = jsonpickle.decode(typ_pickled)


### PR DESCRIPTION
The present `loadclass` implementation fails to correctly loadclass for `builtins.NoneType`.

The PR adds support for this such that decoding will behave appropriately for following example:

```py

some_parms = dict( value_type=(str, type(None)), default=None, some_other_key=42 )
some_parms_enc = jsonpickle.encode(some_parms)
some_parms_dec = jsonpickle.decode(some_parms_enc)

some_parms == some_pars_dec
```