### PR TITLE
unpickler: avoid creating and returning temporary functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Upcoming
 ========
     * ``tests/benchmark.py`` was updated to avoid python2 syntax.
+    * The unpickler was updated to avoid creating temporary functions.
 
 v3.2.1
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+Upcoming
+========
+    * ``tests/benchmark.py`` was updated to avoid python2 syntax.
+
 v3.2.1
 ======
     * The ``ignorereserved`` parameter to the private ``_restore_from_dict()``

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -306,6 +306,11 @@ def has_tag_dict(obj, tag):
     return tag in obj
 
 
+def _passthrough(value):
+    """A function that returns its input as-is"""
+    return value
+
+
 class Unpickler(object):
     def __init__(
         self,
@@ -347,14 +352,11 @@ class Unpickler(object):
             method(obj, attr, proxy)
         self._proxies = []
 
-    def _restore(self, obj):
+    def _restore(self, obj, _passthrough=_passthrough):
         # if obj isn't in these types, neither it nor nothing in it can have a tag
         # don't change the tuple of types to a set, it won't work with isinstance
         if not isinstance(obj, (str, list, dict, set, tuple)):
-
-            def restore(x):
-                return x
-
+            restore = _passthrough
         else:
             restore = self._restore_tags(obj)
         return restore(obj)
@@ -586,7 +588,7 @@ class Unpickler(object):
             )
         return key
 
-    def _restore_key_fn(self):
+    def _restore_key_fn(self, _passthrough=_passthrough):
         """Return a callable that restores keys
 
         This function is responsible for restoring non-string keys
@@ -601,10 +603,7 @@ class Unpickler(object):
         if self.keys:
             restore_key = self._restore_pickled_key
         else:
-
-            def restore_key(key):
-                return key
-
+            restore_key = _passthrough
         return restore_key
 
     def _restore_from_dict(
@@ -867,15 +866,11 @@ class Unpickler(object):
     def _restore_tuple(self, obj):
         return tuple([self._restore(v) for v in obj[tags.TUPLE]])
 
-    def _restore_tags(self, obj):
+    def _restore_tags(self, obj, _passthrough=_passthrough):
         """Return the restoration function for the specified object"""
         try:
             if not tags.RESERVED <= set(obj) and type(obj) not in (list, dict):
-
-                def restore(x):
-                    return x
-
-                return restore
+                return _passthrough
         except TypeError:
             pass
         if type(obj) is dict:
@@ -906,8 +901,5 @@ class Unpickler(object):
         elif util.is_list(obj):
             restore = self._restore_list
         else:
-
-            def restore(x):
-                return x
-
+            restore = _passthrough
         return restore

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -23,7 +23,7 @@ jsonpickle.set_preferred_backend('%s')
 pickled = jsonpickle.encode(doc)
 unpickled = jsonpickle.decode(pickled)
 if doc['feed']['title'] != unpickled['feed']['title']:
-    print 'Not a match'
+    print('Not a match')
 """
 
 


### PR DESCRIPTION
Add a private _passthrough() function that we can return whereever
we would have created a temporary function. This avoids creating
temporary functions and the associated extra allocations that
come along with them.