### PR TITLE
drop python<=3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04]
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 Upcoming
 ========
+    * **Breaking Change**: Python 3.7 is no longer supported.
     * **Breaking Change**: Support for pre-0.7.0 ``repr``-serialized objects is no
       longer enabled by default. The ``safe`` option to ``decode()`` was changed from
       ``False`` to ``True``. Users can still pass ``safe=False`` to ``decode()`` in order

--- a/garden.yaml
+++ b/garden.yaml
@@ -17,8 +17,15 @@ trees:
       check>:
         - test
         - check/fmt
+        - check/pyupgrade
         - doc
-      check/fmt: "garden ${GARDEN_CMD_VERBOSE} fmt -- --check"
+      check/fmt: "garden fmt ${GARDEN_CMD_VERBOSE} -- --check"
+      check/pyupgrade: |
+        ${activate}
+        if type pyupgrade >/dev/null 2>&1
+        then
+            pyupgrade --py38-plus jsonpickle/*.py jsonpickle/*/*.py tests/*.py fuzzing/fuzz-targets/*.py
+        fi
       clean: |
         rm -fr build dist jsonpickle.egg-info
         find . -type d -name __pycache__ -print0 | xargs -0 rm -fr

--- a/garden.yaml
+++ b/garden.yaml
@@ -34,7 +34,7 @@ trees:
         ${activate} python3 -m sphinx docs pages
       fmt: |
         ${activate}
-        black --skip-string-normalization --target-version py37 "$@" jsonpickle tests fuzzing/fuzz-targets
+        black --skip-string-normalization --target-version py38 "$@" jsonpickle tests fuzzing/fuzz-targets
         isort --profile=black "$@" jsonpickle tests fuzzing/fuzz-targets
       setup: |
         test -d env3 || python3 -m venv env3

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
 # Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com)
 # All rights reserved.

--- a/jsonpickle/__init__.py
+++ b/jsonpickle/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
 # Copyright (C) 2009, 2011, 2013 David Aguilar (davvid -at- gmail.com)

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -1,7 +1,7 @@
 from .compat import string_types
 
 
-class JSONBackend(object):
+class JSONBackend:
     """Manages encoding and decoding using various backends.
 
     It tries these modules in this order:

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -147,7 +147,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
         """encode numpy to json"""
         if self.size_threshold is None or self.size_threshold >= obj.size:
             # encode as text
-            data = super(NumpyNDArrayHandlerBinary, self).flatten(obj, data)
+            data = super().flatten(obj, data)
         else:
             # encode as binary
             if obj.dtype == object:
@@ -190,7 +190,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
         values = data['values']
         if isinstance(values, list):
             # decode text representation
-            arr = super(NumpyNDArrayHandlerBinary, self).restore(data)
+            arr = super().restore(data)
         elif isinstance(values, numeric_types):
             # single-value array
             arr = np.array([values], dtype=self.restore_dtype(data))
@@ -256,7 +256,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
             valid values for 'compression' are {zlib, bz2, None}
             if compression is None, no compression is applied
         """
-        super(NumpyNDArrayHandlerView, self).__init__(size_threshold, compression)
+        super().__init__(size_threshold, compression)
         self.mode = mode
 
     def flatten(self, obj, data):
@@ -264,7 +264,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
         base = obj.base
         if base is None and obj.flags.forc:
             # store by value
-            data = super(NumpyNDArrayHandlerView, self).flatten(obj, data)
+            data = super().flatten(obj, data)
             # ensure that views on arrays stored as text
             # are interpreted correctly
             if not obj.flags.c_contiguous:
@@ -309,7 +309,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
                     "not know how to serialize."
                 )
                 raise ValueError(msg)
-            data = super(NumpyNDArrayHandlerView, self).flatten(obj.copy(), data)
+            data = super().flatten(obj.copy(), data)
 
         return data
 
@@ -318,7 +318,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
         base = data.get('base', None)
         if base is None:
             # decode array with owndata=True
-            arr = super(NumpyNDArrayHandlerView, self).restore(data)
+            arr = super().restore(data)
         else:
             # decode array view, which references the data of another array
             base = self.context.restore(base, reset=False)

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -59,7 +59,7 @@ def rle_decode(encoded_list):
     return decoded
 
 
-class PandasProcessor(object):
+class PandasProcessor:
     def __init__(self, size_threshold=500, compression=zlib):
         """
         :param size_threshold: nonnegative int or None

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -20,7 +20,7 @@ import uuid
 from . import compat, util
 
 
-class Registry(object):
+class Registry:
     def __init__(self):
         self._handlers = {}
         self._base_handlers = {}
@@ -68,7 +68,7 @@ class Registry(object):
 
             return _register
         if not util.is_type(cls):
-            raise TypeError('{!r} is not a class/type'.format(cls))
+            raise TypeError(f'{cls!r} is not a class/type')
         # store both the name and the actual type for the ugly cases like
         # _sre.SRE_Pattern that cannot be loaded back directly
         self._handlers[util.importable_name(cls)] = self._handlers[cls] = handler
@@ -88,7 +88,7 @@ unregister = registry.unregister
 get = registry.get
 
 
-class BaseHandler(object):
+class BaseHandler:
     def __init__(self, context):
         """
         Initialize a new handler to handle a registered type.
@@ -231,7 +231,7 @@ class QueueHandler(BaseHandler):
 QueueHandler.handles(compat.queue.Queue)
 
 
-class CloneFactory(object):
+class CloneFactory:
     """Serialization proxy for collections.defaultdict's default_factory"""
 
     def __init__(self, exemplar):
@@ -242,7 +242,7 @@ class CloneFactory(object):
         return clone(self.exemplar)
 
     def __repr__(self):
-        return '<CloneFactory object at 0x{:x} ({})>'.format(id(self), self.exemplar)
+        return f'<CloneFactory object at 0x{id(self):x} ({self.exemplar})>'
 
 
 class UUIDHandler(BaseHandler):
@@ -288,5 +288,4 @@ class TextIOHandler(BaseHandler):
         raise AssertionError('Restoring IO.TextIOHandler is not supported')
 
 
-if sys.version_info >= (3, 8):
-    TextIOHandler.handles(io.TextIOWrapper)
+TextIOHandler.handles(io.TextIOWrapper)

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -13,7 +13,6 @@ import copy
 import datetime
 import io
 import re
-import sys
 import threading
 import uuid
 

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -193,7 +193,7 @@ def _wrap_string_slot(string):
     return string
 
 
-class Pickler(object):
+class Pickler:
     def __init__(
         self,
         unpicklable=True,

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -118,7 +118,7 @@ def _is_json_key(key):
     return isinstance(key, compat.string_types) and key.startswith(tags.JSON_KEY)
 
 
-class _Proxy(object):
+class _Proxy:
     """Proxies are dummy objects that are later replaced by real instances
 
     The `restore()` function has to solve a tricky problem when pickling
@@ -342,7 +342,7 @@ def _passthrough(value):
     return value
 
 
-class Unpickler(object):
+class Unpickler:
     def __init__(
         self,
         backend=None,

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -542,7 +542,7 @@ def importable_name(cls):
                 module = cls.__self__.__module__
             else:
                 module = cls.__self__.__class__.__module__
-    return '{}.{}'.format(module, name)
+    return f'{module}.{name}'
 
 
 def b64encode(data):

--- a/jsonpickle/version.py
+++ b/jsonpickle/version.py
@@ -1,5 +1,3 @@
-import sys
-
 try:
     from importlib import metadata
 except (ImportError, OSError):

--- a/jsonpickle/version.py
+++ b/jsonpickle/version.py
@@ -1,10 +1,7 @@
 import sys
 
 try:
-    if sys.version_info < (3, 8):
-        import importlib_metadata as metadata
-    else:
-        from importlib import metadata
+    from importlib import metadata
 except (ImportError, OSError):
     metadata = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ cov = [
 ]
 dev = [
     "black",
+    "pyupgrade",
 ]
 testing = [
     # core

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -8,18 +8,18 @@ from helper import SkippableTest
 import jsonpickle
 
 
-class Thing(object):
+class Thing:
     def __init__(self, name):
         self.name = name
         self.child = None
 
 
-class A(object):
+class A:
     def __init__(self):
         self.id = md5(str(id(self)).encode()).hexdigest()[:5]  # unique enough hash
 
 
-class BSlots(object):
+class BSlots:
     __slots__ = ["a2", "a1", "a3"]
 
     def __init__(self):
@@ -187,10 +187,10 @@ class YamlTestCase(BackendBase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(JsonTestCase))
-    suite.addTest(unittest.makeSuite(UJsonTestCase))
-    suite.addTest(unittest.makeSuite(SimpleJsonTestCase))
-    suite.addTest(unittest.makeSuite(YamlTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(JsonTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(UJsonTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(SimpleJsonTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(YamlTestCase))
     return suite
 
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
 # All rights reserved.

--- a/tests/bson_test.py
+++ b/tests/bson_test.py
@@ -12,7 +12,7 @@ import jsonpickle
 bson = None
 
 
-class Object(object):
+class Object:
     def __init__(self, offset):
         self.offset = datetime.timedelta(offset)
 

--- a/tests/collections_test.py
+++ b/tests/collections_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This document is free and open-source software, subject to the OSI-approved
 # BSD license below.
@@ -60,19 +59,19 @@ expectation of failure via raising exceptions.
 """
 
 
-class Group(object):
+class Group:
     def __init__(self, name):
-        super(Group, self).__init__()
+        super().__init__()
         self.name = name
         self.elements = []
 
     def __repr__(self):
-        return 'Group({})'.format(self.name)
+        return f'Group({self.name})'
 
 
-class C(object):
+class C:
     def __init__(self, v):
-        super(C, self).__init__()
+        super().__init__()
         self.v = v
         self.plain = dict()
         self.plain_ordered = OrderedDict()
@@ -87,16 +86,16 @@ class C(object):
         return hash(self.v) if hasattr(self, 'v') else id(self)
 
     def __repr__(self):
-        return 'C({})'.format(self.v)
+        return f'C({self.v})'
 
 
 def c_factory():
     return (C(0), '_')
 
 
-class D(object):
+class D:
     def __init__(self, v):
-        super(D, self).__init__()
+        super().__init__()
         self.v = v
         self.plain = set()
 
@@ -107,7 +106,7 @@ class D(object):
         return hash(self.v) if hasattr(self, 'v') else id(self)
 
     def __repr__(self):
-        return 'D({})'.format(self.v)
+        return f'D({self.v})'
 
 
 def pickle_and_unpickle(obj):

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013 Jason R. Coombs <jaraco@jaraco.com>
 # All rights reserved.
@@ -15,7 +14,7 @@ import jsonpickle
 from jsonpickle import tags
 
 
-class ObjWithDate(object):
+class ObjWithDate:
     def __init__(self):
         ts = datetime.datetime.now()
         self.data = dict(a='a', ts=ts)
@@ -39,7 +38,7 @@ class UTC(datetime.tzinfo):
 utc = UTC()
 
 
-class TimestampedVariable(object):
+class TimestampedVariable:
     def __init__(self, value=None):
         self._value = value
         self._dt_read = datetime.datetime.utcnow()
@@ -76,7 +75,7 @@ class TimestampedVariable(object):
         return s
 
 
-class PersistantVariables(object):
+class PersistantVariables:
     def __init__(self):
         self._data = {}
 
@@ -265,9 +264,15 @@ class DateTimeAdvancedTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(DateTimeSimpleTestCase))
-    suite.addTest(unittest.makeSuite(DateTimeAdvancedTestCase))
-    suite.addTest(unittest.makeSuite(DateTimeInnerReferenceTestCase))
+    suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(DateTimeSimpleTestCase)
+    )
+    suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(DateTimeAdvancedTestCase)
+    )
+    suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(DateTimeInnerReferenceTestCase)
+    )
     return suite
 
 

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 import jsonpickle
 
 
-class Node(object):
+class Node:
     def __init__(self, name):
         self._name = name
         self._children = []
@@ -37,7 +35,7 @@ class Question(Node):
         Node.__init__(self, name)
 
     def __str__(self):
-        return 'Question "%s", parent: "%s"\n' % (self._name, self._parent._name)
+        return f'Question "{self._name}", parent: "{self._parent._name}"\n'
 
     def __repr__(self):
         return self.__str__()
@@ -48,7 +46,7 @@ class Section(Node):
         Node.__init__(self, name)
 
     def __str__(self):
-        ret_str = 'Section "%s", parent: "%s"\n' % (self._name, self._parent._name)
+        ret_str = f'Section "{self._name}", parent: "{self._parent._name}"\n'
         for c in self._children:
             ret_str += repr(c)
         return ret_str
@@ -92,7 +90,7 @@ class DocumentTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(DocumentTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DocumentTestCase))
     return suite
 
 

--- a/tests/ecdsa_test.py
+++ b/tests/ecdsa_test.py
@@ -37,7 +37,7 @@ class EcdsaTestCase(SkippableTest):
         if self.should_skip:
             return self.skip('ecdsa module is not installed')
 
-        message = 'test'.encode('utf-8')
+        message = b'test'
         key_pair = self.SigningKey.generate(curve=self.NIST384p)
         sig = key_pair.sign(message)
 

--- a/tests/feedparser_test.py
+++ b/tests/feedparser_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008 John Paulett (john -at- paulett.org)
 # All rights reserved.

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013 Jason R. Coombs <jaraco@jaraco.com>
 # All rights reserved.
@@ -13,7 +12,7 @@ import jsonpickle
 import jsonpickle.handlers
 
 
-class CustomObject(object):
+class CustomObject:
     "A class to be serialized by a custom handler"
 
     def __init__(self, name=None, creator=None):
@@ -143,7 +142,7 @@ class HandlerTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(HandlerTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(HandlerTestCase))
     suite.addTest(doctest.DocTestSuite(jsonpickle.handlers))
     return suite
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -50,7 +50,7 @@ class Capture:
         self.kwargs = kwargs
 
     def __repr__(self):
-        return object.__repr__(self) + ('(%r, %r)' % (self.args, self.kwargs))
+        return object.__repr__(self) + (f'({self.args!r}, {self.kwargs!r})')
 
 
 class ThingWithProps:
@@ -204,12 +204,12 @@ class PicklingTestCase(unittest.TestCase):
         self.assertEqual({tags.B64: encoded}, self.pickler.flatten(data))
 
     def test_decode_base85(self):
-        expected = 'Pÿthöñ 3!'.encode('utf-8')
+        expected = 'Pÿthöñ 3!'.encode()
         pickled = {tags.B85: util.b85encode(expected)}
         self.assertEqual(expected, self.unpickler.restore(pickled))
 
     def test_base85_still_handles_base64(self):
-        expected = 'Pÿthöñ 3!'.encode('utf-8')
+        expected = 'Pÿthöñ 3!'.encode()
         pickled = {tags.B64: util.b64encode(expected)}
         self.assertEqual(expected, self.unpickler.restore(pickled))
 
@@ -948,7 +948,7 @@ class JSONPickleTestCase(SkippableTest):
         self.assertEqual(decoded.name, obj.name)
 
     def test_can_serialize_inner_classes(self):
-        class InnerScope(object):
+        class InnerScope:
             """Private class visible to this method only"""
 
             def __init__(self, name):
@@ -1030,7 +1030,7 @@ class JSONPickleTestCase(SkippableTest):
         self.assertEqual(unpickled, s)
 
 
-class PicklableNamedTuple(object):
+class PicklableNamedTuple:
     """
     A picklable namedtuple wrapper, to demonstrate the need
     for protocol 2 compatibility. Yes, this is contrived in
@@ -1046,7 +1046,7 @@ class PicklableNamedTuple(object):
         return instance
 
 
-class PicklableNamedTupleEx(object):
+class PicklableNamedTupleEx:
     """
     A picklable namedtuple wrapper, to demonstrate the need
     for protocol 4 compatibility. Yes, this is contrived in
@@ -1066,7 +1066,7 @@ class PicklableNamedTupleEx(object):
         return instance
 
 
-class PickleProtocol2Thing(object):
+class PickleProtocol2Thing:
     def __init__(self, *args):
         self.args = args
 
@@ -1096,7 +1096,7 @@ dictmagic = PickleProtocol2Thing('dictmagic')
 
 class PickleProtocol2GetState(PickleProtocol2Thing):
     def __new__(cls, *args):
-        instance = super(PickleProtocol2GetState, cls).__new__(cls)
+        instance = super().__new__(cls)
         instance.newargs = args
         return instance
 
@@ -1135,7 +1135,7 @@ class PickleProtocol2GetSetState(PickleProtocol2GetState):
             self.magic = False
 
 
-class PickleProtocol2ChildThing(object):
+class PickleProtocol2ChildThing:
     def __init__(self, child):
         self.child = child
 
@@ -1143,12 +1143,12 @@ class PickleProtocol2ChildThing(object):
         return ([self.child],)
 
 
-class PickleProtocol2ReduceString(object):
+class PickleProtocol2ReduceString:
     def __reduce__(self):
         return __name__ + '.slotmagic'
 
 
-class PickleProtocol2ReduceExString(object):
+class PickleProtocol2ReduceExString:
     def __reduce_ex__(self, n):
         return __name__ + '.slotmagic'
 
@@ -1156,7 +1156,7 @@ class PickleProtocol2ReduceExString(object):
         assert False, "Should not be here"
 
 
-class PickleProtocol2ReduceTuple(object):
+class PickleProtocol2ReduceTuple:
     def __init__(self, argval, optional=None):
         self.argval = argval
         self.optional = optional
@@ -1172,7 +1172,7 @@ class PickleProtocol2ReduceTuple(object):
 
 
 @compat.iterator
-class ReducibleIterator(object):
+class ReducibleIterator:
     def __next__(self):
         raise StopIteration()
 
@@ -1187,7 +1187,7 @@ def protocol_2_reduce_tuple_func(*args):
     return PickleProtocol2ReduceTupleFunc(*args)
 
 
-class PickleProtocol2ReduceTupleFunc(object):
+class PickleProtocol2ReduceTupleFunc:
     def __init__(self, argval, optional=None):
         self.argval = argval
         self.optional = optional
@@ -1249,7 +1249,7 @@ class PickleProtocol2ReduceTupleSetState(PickleProtocol2ReduceTuple):
         self.bar = state['foo']
 
 
-class PickleProtocol2ReduceTupleStateSlots(object):
+class PickleProtocol2ReduceTupleStateSlots:
     __slots__ = ('argval', 'optional', 'foo')
 
     def __init__(self, argval, optional=None):
@@ -1266,7 +1266,7 @@ class PickleProtocol2ReduceTupleStateSlots(object):
         )
 
 
-class PickleProtocol2ReduceListitemsAppend(object):
+class PickleProtocol2ReduceListitemsAppend:
     def __init__(self):
         self.inner = []
 
@@ -1283,7 +1283,7 @@ class PickleProtocol2ReduceListitemsAppend(object):
         )
 
 
-class PickleProtocol2ReduceListitemsExtend(object):
+class PickleProtocol2ReduceListitemsExtend:
     def __init__(self):
         self.inner = []
 
@@ -1300,7 +1300,7 @@ class PickleProtocol2ReduceListitemsExtend(object):
         )
 
 
-class PickleProtocol2ReduceDictitems(object):
+class PickleProtocol2ReduceDictitems:
     def __init__(self):
         self.inner = {}
 

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -102,9 +102,9 @@ def test_ndarray_roundtrip():
         np.random.random((10, 20)),
         np.array([[True, False, True]]),
         np.array(['foo', 'bar']),
-        np.array(['baz'.encode('utf-8')]),
+        np.array([b'baz']),
         np.array(['2010', 'NaT', '2030']).astype('M'),
-        np.rec.array('abcdefg'.encode('utf-8') * 100, formats='i2,a3,i4', shape=3),
+        np.rec.array(b'abcdefg' * 100, formats='i2,a3,i4', shape=3),
         np.rec.array(
             [
                 (1, 11, 'a'),
@@ -259,7 +259,7 @@ def test_fortran_base():
 
 def test_buffer():
     """test behavior with memoryviews which are not ndarrays"""
-    bstring = 'abcdefgh'.encode('utf-8')
+    bstring = b'abcdefgh'
     a = np.frombuffer(bstring, dtype=np.byte)
     warn_count = 1
     with warnings.catch_warnings(record=True) as w:

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -905,13 +905,6 @@ def test_counter_roundtrip_with_keys():
     assert decoded.get(1) == 2
 
 
-issue281 = pytest.mark.xfail(
-    'sys.version_info >= (3, 8)',
-    reason='https://github.com/jsonpickle/jsonpickle/issues/281',
-)
-
-
-@issue281
 def test_list_with_fd():
     """Serialize a list with an file descriptor"""
     with open(__file__) as fd:
@@ -927,7 +920,6 @@ def _test_list_with_fd(fd):
     assert [None] == newobj
 
 
-@issue281
 def test_thing_with_fd():
     """Serialize an object with a file descriptor"""
     with open(__file__) as fd:
@@ -943,7 +935,6 @@ def _test_thing_with_fd(fd):
     assert newobj.name is None
 
 
-@issue281
 def test_dict_with_fd():
     """Serialize a dict with a file descriptor"""
     with open(__file__) as fd:

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -14,7 +14,7 @@ from jsonpickle import compat, handlers, tags, util
 from jsonpickle.compat import queue
 
 
-class Thing(object):
+class Thing:
     def __init__(self, name):
         self.name = name
         self.child = None
@@ -51,7 +51,7 @@ class GetstateDict(dict):
         self.active = True
 
 
-class GetstateOnly(object):
+class GetstateOnly:
     def __init__(self, a=1, b=2):
         self.a = a
         self.b = b
@@ -60,7 +60,7 @@ class GetstateOnly(object):
         return [self.a, self.b]
 
 
-class GetstateReturnsList(object):
+class GetstateReturnsList:
     def __init__(self, x, y):
         self.x = x
         self.y = y
@@ -72,7 +72,7 @@ class GetstateReturnsList(object):
         self.x, self.y = state[0], state[1]
 
 
-class GetstateRecursesInfintely(object):
+class GetstateRecursesInfintely:
     def __getstate__(self):
         return GetstateRecursesInfintely()
 
@@ -80,13 +80,13 @@ class GetstateRecursesInfintely(object):
 class ListSubclassWithInit(list):
     def __init__(self, attr):
         self.attr = attr
-        super(ListSubclassWithInit, self).__init__()
+        super().__init__()
 
 
 NamedTuple = collections.namedtuple('NamedTuple', 'a, b, c')
 
 
-class ObjWithJsonPickleRepr(object):
+class ObjWithJsonPickleRepr:
     def __init__(self):
         self.data = {'a': self}
 
@@ -106,12 +106,12 @@ def func(x):
     return x
 
 
-class ThingWithFunctionRefs(object):
+class ThingWithFunctionRefs:
     def __init__(self):
         self.fn = func
 
 
-class ThingWithQueue(object):
+class ThingWithQueue:
     def __init__(self):
         self.child_1 = queue.Queue()
         self.child_2 = queue.Queue()
@@ -119,7 +119,7 @@ class ThingWithQueue(object):
         self.childref_2 = self.child_2
 
 
-class ThingWithSlots(object):
+class ThingWithSlots:
     __slots__ = ('a', 'b')
 
     def __init__(self, a, b):
@@ -135,7 +135,7 @@ class ThingWithInheritedSlots(ThingWithSlots):
         self.c = c
 
 
-class ThingWithIterableSlots(object):
+class ThingWithIterableSlots:
     __slots__ = iter('ab')
 
     def __init__(self, a, b):
@@ -143,7 +143,7 @@ class ThingWithIterableSlots(object):
         self.b = b
 
 
-class ThingWithStringSlots(object):
+class ThingWithStringSlots:
     __slots__ = 'ab'
 
     def __init__(self, a, b):
@@ -204,7 +204,7 @@ class SubEnum(enum.Enum):
     b = 2
 
 
-class EnumClass(object):
+class EnumClass:
     def __init__(self):
         self.enum_a = SubEnum.a
         self.enum_b = SubEnum.b
@@ -224,7 +224,7 @@ class MessageCommands(enum.Enum):
     STATUS_ALL = 'STATUS_ALL'
 
 
-class Message(object):
+class Message:
     def __init__(self, message_type, command, status=None, body=None):
         self.message_type = MessageTypes(message_type)
         if command:
@@ -235,7 +235,7 @@ class Message(object):
             self.body = body
 
 
-class ThingWithTimedeltaAttribute(object):
+class ThingWithTimedeltaAttribute:
     def __init__(self, offset):
         self.offset = datetime.timedelta(offset)
 
@@ -244,7 +244,7 @@ class ThingWithTimedeltaAttribute(object):
 
 
 class FailSafeTestCase(SkippableTest):
-    class BadClass(object):
+    class BadClass:
         def __getstate__(self):
             raise ValueError('Intentional error')
 
@@ -275,7 +275,7 @@ class FailSafeTestCase(SkippableTest):
         self.assertEqual(decoded[0], CUSTOM_ERR_MSG)
 
 
-class IntKeysObject(object):
+class IntKeysObject:
     def __init__(self):
         self.data = {0: 0}
 
@@ -285,7 +285,7 @@ class IntKeysObject(object):
 
 class ExceptionWithArguments(Exception):
     def __init__(self, value):
-        super(ExceptionWithArguments, self).__init__('test')
+        super().__init__('test')
         self.value = value
 
 
@@ -914,7 +914,7 @@ issue281 = pytest.mark.xfail(
 @issue281
 def test_list_with_fd():
     """Serialize a list with an file descriptor"""
-    fd = open(__file__, 'r')
+    fd = open(__file__)
     fd.close()
     obj = [fd]
     jsonstr = jsonpickle.encode(obj)
@@ -925,7 +925,7 @@ def test_list_with_fd():
 @issue281
 def test_thing_with_fd():
     """Serialize an object with a file descriptor"""
-    fd = open(__file__, 'r')
+    fd = open(__file__)
     fd.close()
     obj = Thing(fd)
     jsonstr = jsonpickle.encode(obj)
@@ -936,7 +936,7 @@ def test_thing_with_fd():
 @issue281
 def test_dict_with_fd():
     """Serialize a dict with a file descriptor"""
-    fd = open(__file__, 'r')
+    fd = open(__file__)
     fd.close()
     obj = {'fd': fd}
     jsonstr = jsonpickle.encode(obj)
@@ -1102,14 +1102,14 @@ def test_multiple_string_enums_when_make_refs_is_false():
 
 
 # Test classes for ExternalHandlerTestCase
-class Mixin(object):
+class Mixin:
     def ok(self):
         return True
 
 
 class UnicodeMixin(str, Mixin):
     def __add__(self, rhs):
-        obj = super(UnicodeMixin, self).__add__(rhs)
+        obj = super().__add__(rhs)
         return UnicodeMixin(obj)
 
 

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -914,8 +914,13 @@ issue281 = pytest.mark.xfail(
 @issue281
 def test_list_with_fd():
     """Serialize a list with an file descriptor"""
-    fd = open(__file__)
-    fd.close()
+    with open(__file__) as fd:
+        _test_list_with_fd(fd)
+    _test_list_with_fd(fd)  # fd is closed.
+
+
+def _test_list_with_fd(fd):
+    """Serialize a list with an file descriptor"""
     obj = [fd]
     jsonstr = jsonpickle.encode(obj)
     newobj = jsonpickle.decode(jsonstr)
@@ -925,8 +930,13 @@ def test_list_with_fd():
 @issue281
 def test_thing_with_fd():
     """Serialize an object with a file descriptor"""
-    fd = open(__file__)
-    fd.close()
+    with open(__file__) as fd:
+        _test_thing_with_fd(fd)
+    _test_thing_with_fd(fd)  # fd is closed.
+
+
+def _test_thing_with_fd(fd):
+    """Serialize an object with a file descriptor"""
     obj = Thing(fd)
     jsonstr = jsonpickle.encode(obj)
     newobj = jsonpickle.decode(jsonstr)
@@ -936,8 +946,13 @@ def test_thing_with_fd():
 @issue281
 def test_dict_with_fd():
     """Serialize a dict with a file descriptor"""
-    fd = open(__file__)
-    fd.close()
+    with open(__file__) as fd:
+        _test_dict_with_fd(fd)
+    _test_dict_with_fd(fd)
+
+
+def _test_dict_with_fd(fd):
+    """Serialize a dict with a file descriptor"""
     obj = {'fd': fd}
     jsonstr = jsonpickle.encode(obj)
     newobj = jsonpickle.decode(jsonstr)

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -202,7 +202,7 @@ def test_period_roundtrip():
 
 
 def test_interval_roundtrip():
-    obj = pd.Interval(2, 4, closed=str('left'))
+    obj = pd.Interval(2, 4, closed='left')
     decoded_obj = roundtrip(obj)
     assert decoded_obj == obj
 

--- a/tests/stdlib_test.py
+++ b/tests/stdlib_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test miscellaneous objects from the standard library"""
 
 import unittest
@@ -46,8 +45,8 @@ class BytesTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(UUIDTestCase))
-    suite.addTest(unittest.makeSuite(BytesTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(UUIDTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(BytesTestCase))
     return suite
 
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,7 +12,7 @@ import unittest
 from jsonpickle import compat, util
 
 
-class Thing(object):
+class Thing:
     def __init__(self, name):
         self.name = name
         self.child = None
@@ -26,7 +26,7 @@ class ListSubclass(list):
     pass
 
 
-class MethodTestClass(object):
+class MethodTestClass:
     variable = None
 
     @staticmethod
@@ -74,7 +74,7 @@ class UtilTestCase(unittest.TestCase):
 
     def test_is_primitive_bytes(self):
         self.assertFalse(util.is_primitive(b'hello'))
-        self.assertFalse(util.is_primitive('foo'.encode('utf-8')))
+        self.assertFalse(util.is_primitive(b'foo'))
         self.assertTrue(util.is_primitive('foo'))
 
     def test_is_primitive_unicode(self):
@@ -136,7 +136,7 @@ class UtilTestCase(unittest.TestCase):
     def test_is_dictionary_primitive(self):
         self.assertFalse(util.is_dictionary(int()))
         self.assertFalse(util.is_dictionary(None))
-        self.assertFalse(util.is_dictionary(str()))
+        self.assertFalse(util.is_dictionary(''))
 
     def test_is_dictionary_subclass_dict(self):
         self.assertFalse(util.is_dictionary_subclass({}))
@@ -164,7 +164,7 @@ class UtilTestCase(unittest.TestCase):
         self.assertTrue(util.is_function(lambda: False))
 
     def test_is_function_instance_method(self):
-        class Foo(object):
+        class Foo:
             def method(self):
                 pass
 
@@ -237,7 +237,7 @@ class UtilTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(UtilTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(UtilTestCase))
     suite.addTest(doctest.DocTestSuite(util))
     return suite
 

--- a/tests/wizard_test.py
+++ b/tests/wizard_test.py
@@ -12,12 +12,12 @@ import unittest
 from jsonpickle import decode, encode
 
 
-class World(object):
+class World:
     def __init__(self):
         self.wizards = []
 
 
-class Wizard(object):
+class Wizard:
     def __init__(self, world, name):
         self.name = name
         self.spells = collections.OrderedDict()
@@ -27,23 +27,23 @@ class Wizard(object):
         for (ka, va), (kb, vb) in zip(self.spells.items(), other.spells.items()):
             cmp_name = cmp(ka.name, kb.name)  # noqa: F821
             if cmp_name != 0:
-                print('Wizards cmp: %s != %s' % (ka.name, kb.name))
+                print(f'Wizards cmp: {ka.name} != {kb.name}')
                 return cmp_name
             for sa, sb in zip(va, vb):
                 cmp_spell = cmp(sa, sb)  # noqa: F821
                 if cmp_spell != 0:
-                    print('Spells cmp: %s != %s' % (sa.name, sb.name))
+                    print(f'Spells cmp: {sa.name} != {sb.name}')
                     return cmp_spell
         return cmp(self.name, other.name)  # noqa: F821
 
     def __eq__(self, other):
         for (ka, va), (kb, vb) in zip(self.spells.items(), other.spells.items()):
             if ka.name != kb.name:
-                print('Wizards differ: %s != %s' % (ka.name, kb.name))
+                print(f'Wizards differ: {ka.name} != {kb.name}')
                 return False
             for sa, sb in zip(va, vb):
                 if sa != sb:
-                    print('Spells differ: %s != %s' % (sa.name, sb.name))
+                    print(f'Spells differ: {sa.name} != {sb.name}')
                     return False
         return self.name == other.name
 
@@ -51,7 +51,7 @@ class Wizard(object):
         return hash('Wizard %s' % self.name)
 
 
-class Spell(object):
+class Spell:
     def __init__(self, caster, target, name):
         self.caster = caster
         self.target = target
@@ -77,9 +77,7 @@ class Spell(object):
         )
 
     def __hash__(self):
-        return hash(
-            'Spell %s by %s on %s' % (self.name, self.caster.name, self.target.name)
-        )
+        return hash(f'Spell {self.name} by {self.caster.name} on {self.target.name}')
 
 
 def hashsum(items):
@@ -89,7 +87,7 @@ def hashsum(items):
 def compare_spells(a, b):
     for (ka, va), (kb, vb) in zip(a.items(), b.items()):
         if ka != kb:
-            print('Keys differ: %s != %s' % (ka, kb))
+            print(f'Keys differ: {ka} != {kb}')
             return False
     return True
 

--- a/tests/zoneinfo_test.py
+++ b/tests/zoneinfo_test.py
@@ -24,7 +24,9 @@ if sys.version_info >= (3, 9):
 
     def suite():
         suite = unittest.TestSuite()
-        suite.addTest(unittest.makeSuite(ZoneInfoSimpleTestCase))
+        suite.addTest(
+            unittest.defaultTestLoader.loadTestsFromTestCase(ZoneInfoSimpleTestCase)
+        )
         return suite
 
     if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0
-envlist = clean,py36,py37,py38,py39,py310,py311,py312,py313,report
+envlist = clean,py38,py39,py310,py311,py312,py313,report
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,8 +11,8 @@ passenv =
 commands =
 	python3 -m pytest --cov --cov-append --cov-report=term-missing jsonpickle tests {posargs}
 depends =
-	{py36,py37,py38,py39,py310,py311,py312,py313}: clean
-	report: py36,py37,py38,py39,py310,py311,py312,py313
+	{py38,py39,py310,py311,py312,py313}: clean
+	report: py38,py39,py310,py311,py312,py313
 extras =
 	cov
 	testing


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgrade --py38-plus`.