### PR TITLE
Add basic benchmarking scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ __pycache__
 # Local benchmarking files for Theelx
 kern*.py
 *.lprof
+benchmark-*.json
+perf.csv
+perf.svg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ v3.2.2
 ======
     * A bug with the incorrect (de)serialization of NoneType objects has been fixed.
       (+507)
+    * Some basic scripts have been made to analyze benchmark results. (+511)
 
 v3.2.1
 ======

--- a/benchmarking/analyze_benchmarks.py
+++ b/benchmarking/analyze_benchmarks.py
@@ -1,0 +1,56 @@
+import csv
+
+# makes math far easier
+import numpy as np
+
+
+def filter_results_by_name(results, substr):
+    perfs = []
+    for name, perf in results.items():
+        if substr in name:
+            perfs.append(perf)
+    return np.array(perfs)
+
+
+def main():
+    # using dicts seems easier at first but we'd have to eventually convert
+    # to a list for easy elementwise division or use an ugly loop
+    funcs = []
+    main = []
+    new = []
+
+    with open("perf.csv", "r") as f:
+        csv_reader = csv.reader(f)
+        # skip header row
+        next(csv_reader)
+        
+        # csv is sorted by name so we can assume even rows are main and odd are new
+        for indx, (func, median) in enumerate(csv_reader):
+            func = func.split("::")[-1]
+            # indx is even
+            if not (indx % 2):
+                funcs.append(func)
+                main.append(float(median))
+            else:
+                new.append(float(median))
+        
+    main = np.array(main)
+    new = np.array(new)
+        
+    relative_perfs = new / main
+    # more stats will be included when needed
+    print(f"The new branch is {round(relative_perfs.mean(), 4)}x faster than the main branch aross all tests!")
+
+    results = {}
+
+    for func_name, relative_perf in zip(funcs, relative_perfs):
+        # this allows us to categorize classes of results, such as encode vs decode
+        results[func_name] = relative_perf
+    
+    encode_perfs = filter_results_by_name(results, "encode")
+    decode_perfs = filter_results_by_name(results, "decode")
+    print(f"The new branch is {round(encode_perfs.mean(), 4)}x faster than the main branch aross encode tests!")
+    print(f"The new branch is {round(decode_perfs.mean(), 4)}x faster than the main branch aross decode tests!")
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/analyze_benchmarks.py
+++ b/benchmarking/analyze_benchmarks.py
@@ -23,7 +23,7 @@ def main():
         csv_reader = csv.reader(f)
         # skip header row
         next(csv_reader)
-        
+
         # csv is sorted by name so we can assume even rows are main and odd are new
         for indx, (func, median) in enumerate(csv_reader):
             func = func.split("::")[-1]
@@ -33,24 +33,31 @@ def main():
                 main.append(float(median))
             else:
                 new.append(float(median))
-        
+
     main = np.array(main)
     new = np.array(new)
-        
+
     relative_perfs = new / main
     # more stats will be included when needed
-    print(f"The new branch is {round(relative_perfs.mean(), 4)}x faster than the main branch aross all tests!")
+    print(
+        f"The new branch is {round(relative_perfs.mean(), 4)}x faster than the main branch aross all tests!"
+    )
 
     results = {}
 
     for func_name, relative_perf in zip(funcs, relative_perfs):
         # this allows us to categorize classes of results, such as encode vs decode
         results[func_name] = relative_perf
-    
+
     encode_perfs = filter_results_by_name(results, "encode")
     decode_perfs = filter_results_by_name(results, "decode")
-    print(f"The new branch is {round(encode_perfs.mean(), 4)}x faster than the main branch aross encode tests!")
-    print(f"The new branch is {round(decode_perfs.mean(), 4)}x faster than the main branch aross decode tests!")
+    print(
+        f"The new branch is {round(encode_perfs.mean(), 4)}x faster than the main branch aross encode tests!"
+    )
+    print(
+        f"The new branch is {round(decode_perfs.mean(), 4)}x faster than the main branch aross decode tests!"
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/benchmarking/analyze_benchmarks.sh
+++ b/benchmarking/analyze_benchmarks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+DATEANDTIME=$(date +%Y-%m-%dT%T%z)
+pytest --benchmark-only --benchmark-disable-gc --benchmark-json=./benchmark-new.json --benchmark-histogram=../images/benchmark-$DATEANDTIME ../jsonpickle_benchmarks.py
+# assuming the user is doing work in a different branch than main
+git checkout main
+pytest --benchmark-only --benchmark-disable-gc --benchmark-json=./benchmark-main.json --benchmark-histogram=../images/benchmark-$DATEANDTIME ../jsonpickle_benchmarks.py
+# return to previous branch
+git checkout -
+pytest-benchmark compare --columns=median --name=long --sort=fullname --csv=perf --histogram=perf benchmark-main.json benchmark-new.json
+python3 analyze_benchmarks.py


### PR DESCRIPTION
Currently, we've been relying on eyeballing the pytest-benchmark histograms generated between different changesets to catch performance regressions, which is prone to human error. This PR adds a bash script to run then analyze benchmarks, called ``benchmarking/analyze_benchmarks.sh``. At the moment, this allows us to see the overall speed change between the new changeset versus the main branch, plus the speed change for encoding and decoding functions. These scripts will be expanded eventually to allow for more types of filtering and visualizations, but they'll have to do for now.