### PR TITLE
Test fixes for NumPy 2

### DIFF
--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -32,9 +32,7 @@ def test_dtype_roundtrip():
     dtypes = [
         np.int_,
         np.int32,
-        np.float_,
         np.float64,
-        np.complex_,
         np.complex128,
         np.str_,
         np.object_,
@@ -86,15 +84,14 @@ def test_generic_roundtrip():
     values = [
         np.int_(1),
         np.int32(-2),
-        np.float_(2.5),
+        np.float64(2.5),
         np.nan,
         -np.inf,
         np.inf,
         np.datetime64('2014-01-01'),
         np.str_('foo'),
-        np.unicode_('bar'),
         np.object_({'a': 'b'}),
-        np.complex_(1 - 2j),
+        np.complex128(1 - 2j),
     ]
     for value in values:
         decoded = roundtrip(value)

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -306,18 +306,22 @@ def test_immutable():
 def test_byteorder():
     """Test the byteorder for text and binary encodings"""
     # small arr is stored as text
-    a = np.arange(10).newbyteorder()
-    b = a[:].newbyteorder()
-    _a, _b = roundtrip([a, b])
-    npt.assert_array_equal(a, _a)
-    npt.assert_array_equal(b, _b)
+    a = np.arange(10)
+    av = a.view(a.dtype.newbyteorder())
+    b = a[:]
+    bv = b.view(b.dtype.newbyteorder())
+    _av, _bv = roundtrip([av, bv])
+    npt.assert_array_equal(av, _av)
+    npt.assert_array_equal(bv, _bv)
 
     # bigger arr is stored as binary
-    a = np.arange(100).newbyteorder()
-    b = a[:].newbyteorder()
-    _a, _b = roundtrip([a, b])
-    npt.assert_array_equal(a, _a)
-    npt.assert_array_equal(b, _b)
+    a = np.arange(100)
+    av = a.view(a.dtype.newbyteorder())
+    b = a[:]
+    bv = b.view(b.dtype.newbyteorder())
+    _av, _bv = roundtrip([av, bv])
+    npt.assert_array_equal(av, _av)
+    npt.assert_array_equal(bv, _bv)
 
 
 def test_zero_dimensional_array():

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -34,14 +34,13 @@ def test_series_roundtrip():
     ser = pd.Series(
         {
             'an_int': np.int_(1),
-            'a_float': np.float_(2.5),
+            'a_float': np.float64(2.5),
             'a_nan': np.nan,
             'a_minus_inf': -np.inf,
             'an_inf': np.inf,
             'a_str': np.str_('foo'),
-            'a_unicode': np.unicode_('bar'),
             'date': np.datetime64('2014-01-01'),
-            'complex': np.complex_(1 - 2j),
+            'complex': np.complex128(1 - 2j),
             # TODO: the following dtypes are not currently supported.
             # 'object': np.object_({'a': 'b'}),
         }
@@ -54,14 +53,13 @@ def test_dataframe_roundtrip():
     df = pd.DataFrame(
         {
             'an_int': np.int_([1, 2, 3]),
-            'a_float': np.float_([2.5, 3.5, 4.5]),
+            'a_float': np.float64([2.5, 3.5, 4.5]),
             'a_nan': np.array([np.nan] * 3),
             'a_minus_inf': np.array([-np.inf] * 3),
             'an_inf': np.array([np.inf] * 3),
             'a_str': np.str_('foo'),
-            'a_unicode': np.unicode_('bar'),
             'date': np.array([np.datetime64('2014-01-01')] * 3, dtype="datetime64[s]"),
-            'complex': np.complex_([1 - 2j, 2 - 1.2j, 3 - 1.3j]),
+            'complex': np.complex128([1 - 2j, 2 - 1.2j, 3 - 1.3j]),
             # TODO: the following dtypes are not currently supported.
             # 'object': np.object_([{'a': 'b'}]*3),
         }
@@ -76,12 +74,11 @@ def test_multindex_dataframe_roundtrip():
             'idx_lvl0': ['a', 'b', 'c'],
             'idx_lvl1': np.int_([1, 1, 2]),
             'an_int': np.int_([1, 2, 3]),
-            'a_float': np.float_([2.5, 3.5, 4.5]),
+            'a_float': np.float64([2.5, 3.5, 4.5]),
             'a_nan': np.array([np.nan] * 3),
             'a_minus_inf': np.array([-np.inf] * 3),
             'an_inf': np.array([np.inf] * 3),
             'a_str': np.str_('foo'),
-            'a_unicode': np.unicode_('bar'),
         }
     )
     df = df.set_index(['idx_lvl0', 'idx_lvl1'])


### PR DESCRIPTION
Fixes to make the test suite pass with both NumPy 1.x and NumPy 2.x. More details in the commit messages.