### PR TITLE
tags: use py/mod tags for modules instead of py/repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+Upcoming
+========
+
+    * **Breaking Change**: Support for pre-0.7.0 ``repr``-serialized objects is no
+      longer enabled by default. The ``safe`` option to ``decode()`` was changed from
+      ``False`` to ``True``. Users can still pass ``safe=False`` to ``decode()`` in order
+      to enable this feature for the purposes of loading older files, but beware that
+      this feature relies on unsafe behavior through its use of ``eval()``. Users are
+      encouraged to re-pickle old data in order to migrate away from the the unsafe loading
+      feature. (+514)
+    * The pickler no longer produces ``py/repr`` tags when pickling modules.
+      ``py/mod`` is used instead, as it is clearer and uses one less byte. (+514)
+
 v3.3.0
 ======
     * The unpickler was updated to avoid using ``eval``, which helps improve its

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -670,7 +670,7 @@ class Pickler(object):
 
         if util.is_module(obj):
             if self.unpicklable:
-                data[tags.REPR] = '{name}/{name}'.format(name=obj.__name__)
+                data[tags.MODULE] = '{name}/{name}'.format(name=obj.__name__)
             else:
                 data = compat.ustr(obj)
             return data

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -15,6 +15,7 @@ ID = 'py/id'
 INITARGS = 'py/initargs'
 ITERATOR = 'py/iterator'
 JSON_KEY = 'json://'
+MODULE = 'py/mod'
 NEWARGS = 'py/newargs'
 NEWARGSEX = 'py/newargsex'
 NEWOBJ = 'py/newobj'
@@ -36,6 +37,7 @@ RESERVED = {
     ID,
     INITARGS,
     ITERATOR,
+    MODULE,
     NEWARGS,
     NEWARGSEX,
     NEWOBJ,

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -241,9 +241,10 @@ class DateTimeAdvancedTestCase(unittest.TestCase):
         obj = datetime.datetime.now()
         pickler = jsonpickle.pickler.Pickler(unpicklable=False)
         flattened = pickler.flatten(obj)
-        self.assertFalse(tags.REPR in flattened)
-        self.assertFalse(tags.OBJECT in flattened)
-        self.assertEqual(obj.isoformat(), flattened)
+        assert tags.REPR not in flattened
+        assert tags.MODULE not in flattened
+        assert tags.OBJECT not in flattened
+        assert obj.isoformat() == flattened
 
     def test_datetime_dict_keys_defaults(self):
         """Test that we handle datetime objects as keys."""

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -404,7 +404,7 @@ class PicklingTestCase(unittest.TestCase):
         flattened = self.pickler.flatten(obj)
         self.unpickler.safe = True
         inflated = self.unpickler.restore(flattened)
-        self.assertEqual(inflated.themodule, None)
+        assert inflated.themodule is os
 
     def test_thing_with_submodule(self):
         obj = Thing('with-submodule')


### PR DESCRIPTION
A continuation of the ideas from #513 which we can refine after that PR is merged.