### PR TITLE
Issue 126: Allow objects with non-data encoding iterators to be handled.

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -35,7 +35,7 @@ def encode(
     separators=None,
     include_properties=False,
     handle_readonly=False,
-        ignore_iterator=False
+    ignore_iterator=False
 ):
     """Return a JSON formatted representation of value, a Python object.
 

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -188,6 +188,25 @@ class ThingWithDefaultFactory:
         # Keep track of how many times this constructor has been run.
         ThingWithDefaultFactoryRegistry.count += 1
 
+class ThingWithIteratorPlusData:
+    """ Class that has an iterator and more"""
+    def __init__(self, a):
+        self.a = a
+        self._data = [3,1,4,1,5,9]
+        self._index = 0
+
+    def __iter__(self):
+        self._index = 0
+        return self
+
+    def __next__(self):
+        try:
+            item = self._data[self._index]
+        except IndexError as e:
+            raise StopIteration from e
+        self._index += 1
+        return item
+
 
 class IntEnumTest(enum.IntEnum):
     X = 1
@@ -1139,6 +1158,13 @@ def test_datetime_with_tz_copies_refs():
     assert len(decoded) == 2
     assert decoded[0] == d0
     assert decoded[1] == d1
+
+def test_iterator_plus():
+    obj = ThingWithIteratorPlusData(1)
+    encoded = jsonpickle.encode(obj, ignore_iterator=True)
+    decoded = jsonpickle.decode(encoded)
+    assert hasattr(decoded, 'a')
+    assert decoded.a == obj.a
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If an object is an iterator and also has its own data then the data won't be encoded, just the iterator. This PR adds a flag to ignore the iterator.

A better solution would be to encode both iterator and data.