### PR TITLE
Add Usage section to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ __pycache__
 *#*
 *~
 *.tar.gz
-examples/example.txt
+examples/example.json
 
 # Local benchmarking files for Theelx
 kern*.py

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__
 *#*
 *~
 *.tar.gz
+examples/example.txt
 
 # Local benchmarking files for Theelx
 kern*.py

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,12 @@ For complete documentation, please visit the
 Bug reports and merge requests are encouraged at the
 `jsonpickle repository on github <https://github.com/jsonpickle/jsonpickle>`_.
 
+Usage
+=====
+
+See the `examples directory on GitHub <https://github.com/jsonpickle/jsonpickle/tree/main/examples>`_ for example scripts. These can be run on your local machine to see how jsonpickle works and behaves, and how to use it. Contributions from users regarding how they use jsonpickle are welcome!
+
+
 Why jsonpickle?
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,31 @@ Bug reports and merge requests are encouraged at the
 
 Usage
 =====
+The following is a very simple example of how one can use jsonpickle in their scripts/projects. Note the usage of jsonpickle.encode and decode, and how the data is written/encoded to a file and then read/decoded from the file.
 
-See the `examples directory on GitHub <https://github.com/jsonpickle/jsonpickle/tree/main/examples>`_ for example scripts. These can be run on your local machine to see how jsonpickle works and behaves, and how to use it. Contributions from users regarding how they use jsonpickle are welcome!
+.. code-block:: python
+
+    import jsonpickle
+    from dataclasses import dataclass
+   
+    @dataclass
+    class Example:
+        data: str
+   
+   
+    ex = Example("value1")
+    encoded_instance = jsonpickle.encode(ex)
+    assert encoded_instance == '{"py/object": "__main__.Example", "data": "value1"}'
+   
+    with open("example.json", "w+") as f:
+        f.write(encoded_instance)
+   
+    with open("example.json", "r+") as f:
+        written_instance = f.read()
+        decoded_instance = jsonpickle.decode(written_instance)
+    assert decoded_instance == ex
+
+For more examples, see the `examples directory on GitHub <https://github.com/jsonpickle/jsonpickle/tree/main/examples>`_ for example scripts. These can be run on your local machine to see how jsonpickle works and behaves, and how to use it. Contributions from users regarding how they use jsonpickle are welcome!
 
 
 Why jsonpickle?

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+## Purpose
+This directory exists to provide examples of how to use jsonpickle to achieve simple goals, such as:
+- Saving instances of a class to a file
+- And more to come!

--- a/examples/example.txt
+++ b/examples/example.txt
@@ -1,1 +1,0 @@
-{"py/object": "__main__.Example", "data": {"BAR": 1, "foo": 0}}

--- a/examples/example.txt
+++ b/examples/example.txt
@@ -1,0 +1,1 @@
+{"py/object": "__main__.Example", "data": {"BAR": 1, "foo": 0}}

--- a/examples/save_class_to_file.py
+++ b/examples/save_class_to_file.py
@@ -1,0 +1,51 @@
+import jsonpickle
+
+from utilities import ensure_no_files_overwritten
+
+ensure_no_files_overwritten(
+    expected_contents='{"py/object": "__main__.Example", "data": {"BAR": 1, "foo": 0}}'
+)
+
+
+class Example:
+    def __init__(self):
+        self.data = {"foo": 0, "BAR": 1}
+
+    def get_foo(self):
+        return self.data["foo"]
+
+    def __eq__(self, other):
+        # ensure that jsonpickle preserves important stuff like data across encode/decoding
+        return self.data == other.data and self.get_foo() == other.get_foo()
+
+
+# instantiate the class
+ex = Example()
+# encode the class. this returns a string, like json.dumps
+encoded_instance = jsonpickle.encode(ex)
+assert (
+    encoded_instance
+    == '{"py/object": "__main__.Example", "data": {"BAR": 1, "foo": 0}}'
+)
+print(
+    f"jsonpickle successfully encoded the instance of the Example class! It looks like: {encoded_instance}"
+)
+
+
+with open("example.txt", "w+") as f:
+    f.write(encoded_instance)
+    print(
+        f"jsonpickle successfully wrote the instance of the Example class to example.txt!"
+    )
+
+with open("example.txt", "r+") as f:
+    written_instance = f.read()
+    # decode the file into a copy of the original object
+    decoded_instance = jsonpickle.decode(written_instance)
+    print("jsonpickle successfully decoded the instance of the Example class!")
+
+# this should be true, if it isn't then you should file a bug report
+assert decoded_instance == ex
+print(
+    "jsonpickle successfully decoded the instance of the Example class, and it matches the original instance!"
+)

--- a/examples/save_class_to_file.py
+++ b/examples/save_class_to_file.py
@@ -1,6 +1,6 @@
-import jsonpickle
-
 from utilities import ensure_no_files_overwritten
+
+import jsonpickle
 
 ensure_no_files_overwritten(
     expected_contents='{"py/object": "__main__.Example", "data": {"BAR": 1, "foo": 0}}'

--- a/examples/save_class_to_file.py
+++ b/examples/save_class_to_file.py
@@ -32,13 +32,13 @@ print(
 )
 
 
-with open("example.txt", "w+") as f:
+with open("example.json", "w+") as f:
     f.write(encoded_instance)
     print(
-        f"jsonpickle successfully wrote the instance of the Example class to example.txt!"
+        "jsonpickle successfully wrote the instance of the Example class to example.json!"
     )
 
-with open("example.txt", "r+") as f:
+with open("example.json", "r+") as f:
     written_instance = f.read()
     # decode the file into a copy of the original object
     decoded_instance = jsonpickle.decode(written_instance)

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -4,7 +4,7 @@ import sys
 
 def ensure_no_files_overwritten(expected_contents):
     # ensure we don't overwrite the user's files, if they run it on their machine
-    if os.path.exists('example.json'):
+    if os.path.exists("example.json"):
         with open("example.json", "r") as f:
             contents = f.read()
         if contents != expected_contents:

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -4,12 +4,9 @@ import sys
 
 def ensure_no_files_overwritten(expected_contents):
     # ensure we don't overwrite the user's files, if they run it on their machine
-    if os.path.exists(os.path.join(os.getcwd(), 'example.txt')):
-        with open("example.txt", "r") as f:
+    if os.path.exists(os.path.join(os.getcwd(), 'example.json')):
+        with open("example.json", "r") as f:
             contents = f.read()
         if contents != expected_contents:
-            print(
-                "I don't want to overwrite the example.txt file in my current directory! Please delete example.txt and try again!"
-            )
             # exit with a non-zero error code
-            sys.exit(1)
+            sys.exit("I don't want to overwrite the example.json file in my current directory! Please delete example.txt and try again!")

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+
+def ensure_no_files_overwritten(expected_contents):
+    # ensure we don't overwrite the user's files, if they run it on their machine
+    if os.path.exists(os.path.join(os.getcwd(), 'example.txt')):
+        with open("example.txt", "r") as f:
+            contents = f.read()
+        if contents != expected_contents:
+            print(
+                "I don't want to overwrite the example.txt file in my current directory! Please delete example.txt and try again!"
+            )
+            # exit with a non-zero error code
+            sys.exit(1)

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -9,4 +9,6 @@ def ensure_no_files_overwritten(expected_contents):
             contents = f.read()
         if contents != expected_contents:
             # exit with a non-zero error code
-            sys.exit("I don't want to overwrite the example.json file in my current directory! Please delete example.txt and try again!")
+            sys.exit(
+                "I don't want to overwrite the example.json file in my current directory! Please delete example.txt and try again!"
+            )

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -4,7 +4,7 @@ import sys
 
 def ensure_no_files_overwritten(expected_contents):
     # ensure we don't overwrite the user's files, if they run it on their machine
-    if os.path.exists(os.path.join(os.getcwd(), 'example.json')):
+    if os.path.exists('example.json'):
         with open("example.json", "r") as f:
             contents = f.read()
         if contents != expected_contents:


### PR DESCRIPTION
This addresses part of #484 by making a short example script which shows how jsonpickle can be used. Todo would be to include an even shorter code snippet in the README itself, as with this change the README just links to the newly-made examples directory in the GitHub repo. This PR also adds some basic utilities for future example scripts, which could showcase numpy extension support, getstate usage, and more advanced topics.