### PR TITLE
ci: remove github action that creates commits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,5 @@
 name: Lint
 
-permissions:
-   contents: write
-
 on:
   push:
     branches:
@@ -19,31 +16,12 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Run isort check
-        uses: isort/isort-action@master
-        with:
-            configuration: "--check-only --diff --profile black"
-
-      - name: Run isort
-        if: failure()
-        uses: isort/isort-action@master
-        with:
-            configuration: "--profile black"
-
       - name: Run black check
         uses: psf/black@stable
         with:
           options: "--check --diff"
 
-      - name: Run black format
-        if: failure()
-        uses: psf/black@stable
+      - name: Run isort check
+        uses: isort/isort-action@master
         with:
-          options: ""
-
-      - name: Commit isort+black format
-        if: failure()
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Apply black to code"
-
+            configuration: "--check-only --diff --profile black"


### PR DESCRIPTION
Remove the write permission and the committing of code so that github
bots are no longer creating commits. That was an interesting setup, but
it also leads to surprises where github's branch will advance beyond
what we push.
    
Run black before isort since errors in black have a higher chance
of occuring.