### PR TITLE
Ignore examples for pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-collect_ignore = ['contrib']
+collect_ignore = ['contrib', 'examples']
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Ignore the examples dir for pytest, since the results of certain commands depend on whether it's being executed in pytest or directly. A follow-up PR will include info in the README to show how to run examples. Fixes #521.