### PR TITLE
Include how to run examples in README

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-collect_ignore = ['contrib']
+collect_ignore = ['contrib', 'examples']
 
 
 def pytest_addoption(parser):

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,3 +2,39 @@
 This directory exists to provide examples of how to use jsonpickle to achieve simple goals, such as:
 - Saving instances of a class to a file
 - And more to come!
+
+## Running the code
+### Linux (Ubuntu)
+If you don't have python and/or git installed, install those first:
+```sh
+apt install git python3 python3-dev python3-pip
+```
+Once you have those installed, start by cloning the repository and entering into the directory (or copying the file locally):
+```sh
+git clone https://github.com/jsonpickle/jsonpickle.git && cd jsonpickle/examples
+```
+Then, you should install jsonpickle:
+```sh
+pip install jsonpickle
+```
+Lastly, you can run any example file as long as you have jsonpickle and Python installed!
+```sh
+python3 save_class_to_file.py
+```
+You can also open the .py file in your favorite text editor, such as VSCode, gedit, or others!
+### Windows
+If you don't have python, pip, and/or git installed, install those first. Instructions are not included here due to their verbosity, but there exist online guides for this!
+Once you have those installed, start by cloning the repository in a terminal (such as cmd prompt) and entering into the directory (or copying the file locally):
+```sh
+git clone https://github.com/jsonpickle/jsonpickle.git
+cd jsonpickle/examples
+```
+Then, you should install jsonpickle in the same terminal:
+```sh
+pip install jsonpickle
+```
+Lastly, you can run any example file as long as you have jsonpickle and Python installed!
+```sh
+python save_class_to_file.py
+```
+You can also open the .py file in your favorite text editor, such as VSCode, Notepad++, or others!

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,21 @@ Once you have those installed, start by cloning the repository and entering into
 ```sh
 git clone https://github.com/jsonpickle/jsonpickle.git && cd jsonpickle/examples
 ```
-Then, you should install jsonpickle:
+Then, you should install jsonpickle. The preferred method, using a virtual environment (which isolates packages), goes as so:
+```sh
+# DO NOT RUN LINES BEGINNING WITH #
+# Create a virtualenv in the "env" directory. You don't need to run this again.
+python3 -m venv env
+
+# You must activate the virtualenv anytime you open a new shell in order to
+# make the to-be-installed jsonpickle package available. You should run this
+# in the same directory that you ran the previous command in.
+source env/bin/activate
+
+pip install jsonpickle
+python3 save_class_to_file.py
+```
+If you'd rather install jsonpickle globally though, you can just run this:
 ```sh
 pip install jsonpickle
 ```
@@ -29,7 +43,23 @@ Once you have those installed, start by cloning the repository in a terminal (su
 git clone https://github.com/jsonpickle/jsonpickle.git
 cd jsonpickle/examples
 ```
-Then, you should install jsonpickle in the same terminal:
+Then, you should install jsonpickle in the same terminal. The preferred method, using a virtual environment (which isolates packages), goes as so:
+```sh
+pip install virtualenv
+
+# DO NOT RUN LINES BEGINNING WITH #
+# Create a virtualenv in the "env" directory. You don't need to run this again.
+virtualenv venv
+
+# You must activate the virtualenv anytime you open a new shell in order to
+# make the to-be-installed jsonpickle package available. You should run this
+# in the same directory that you ran the previous command in.
+.\venv\Scripts\activate
+
+pip install jsonpickle
+python save_class_to_file.py
+```
+If you'd rather install jsonpickle globally though, you can just run this:
 ```sh
 pip install jsonpickle
 ```


### PR DESCRIPTION
This PR just includes some extra info about how to run examples in the examples/README.md file. I didn't include full instructions for Mac because it should be similar to Linux, nor non-Ubuntu Linux distros because I don't use them. Also the Windows instructions simply tell the user to follow online guides for installing Python and Git as many exist, but at some point I want to include short directions inside this file, This PR should be squashed when merged.