### PR TITLE
Support 3 12 & Update GHA Versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run black check
         uses: psf/black@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04]
 
     steps:
@@ -43,7 +43,7 @@ jobs:
           python -m pip install -U "tox>=4"
 
       - name: Install gmpy2 dependencies
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.11' || matrix.python-version == '3.12'
         run: |
           sudo apt-get -y update
           sudo apt-get install -y libmpfr-dev libmpc-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -28,7 +28,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ testing =
 	bson
 	ecdsa
 	feedparser
-	gmpy2; python_version<"3.12"
+	gmpy2
 	numpy
 	pandas
 	pymongo


### PR DESCRIPTION
This PR is relatively straightforward, just adding support for Python 3.12 in the testing matrix as well as updating the versions of various actions used in the test/lint workflows. While they could be two separate PRs, I did them in one because they both touch GitHub Actions, and because I think of them as both updating versions. The only thing I'm unsure about is whether gmpy2 should be explicitly required to be at least 2.2.0 for Python 3.12 or not, as technically 2.2.0 is the first version that supports 3.12/3.13.