### PR TITLE
Adding missing dependency for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testing = [
     "sqlalchemy",
     "ujson",
     # fuzzing
-    "atheris ~= 2.3.0",
+    "atheris ~= 2.3.0; python_version < '3.12'",
 ]
 docs = [
     "furo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ testing = [
     "simplejson",
     "sqlalchemy",
     "ujson",
+    # fuzzing
+    "atheris ~= 2.3.0",
 ]
 docs = [
     "furo",


### PR DESCRIPTION
In #525, the file ``fuzzing/fuzz-targets/utils.py`` has a line that imports atheris, and pytest checks this file for tests, which causes an error when running pytest. However by default atheris is not installed with the testing setup, so this PR fixes that. Another possible solution is to exclude this file from being checked by pytest, but since fuzzing is so closely integrated with testing, I figure it's better to just add atheris as a testing dependency. Let me know which approach you think is better.