### PR TITLE
API: remove breaking changes for v3.4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Upcoming
     * The pickler no longer produces ``py/repr`` tags when pickling modules.
       ``py/mod`` is used instead, as it is clearer and uses one less byte. (+514)
 
+v3.4.2
+======
+    * The breaking changes from v4 were inadvertedly included in v3.4.1, which has
+      been yanked. This release remedies this by reverting the v4 changes.
+
 v3.4.1
 ======
     * Support decoding pandas dataframes encoded with versions 3.3.0 and older. (+536)

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -670,7 +670,7 @@ class Pickler(object):
 
         if util.is_module(obj):
             if self.unpicklable:
-                data[tags.MODULE] = '{name}/{name}'.format(name=obj.__name__)
+                data[tags.REPR] = '{name}/{name}'.format(name=obj.__name__)
             else:
                 data = compat.ustr(obj)
             return data

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -19,7 +19,7 @@ def decode(
     context=None,
     keys=False,
     reset=True,
-    safe=True,
+    safe=False,
     classes=None,
     v1_decode=False,
     on_missing='ignore',
@@ -45,9 +45,9 @@ def decode(
         This flag is not typically used outside of a custom handler or
         `__getstate__` implementation.
 
-    :param safe: If set to ``False``, use of ``eval()`` for backwards-compatible (pre-0.7.0)
-        deserialization of repr-serialized objects is enabled. Defaults to ``True``.
-        The default value was ``False`` in jsonpickle v3 and changed to ``True`` in jsonpickle v4.
+    :param safe: If set to False, use of ``eval()`` for backwards-compatible (pre-0.7.0)
+        deserialization of repr-serialized objects is enabled. Defaults to False.
+        The default value will change to True in jsonpickle v4.
 
         .. warning::
 
@@ -347,7 +347,7 @@ class Unpickler(object):
         self,
         backend=None,
         keys=False,
-        safe=True,
+        safe=False,
         v1_decode=False,
         on_missing='ignore',
         handle_readonly=False,


### PR DESCRIPTION
v3.4.1 should have been released from the "maint/v3" branch but it was released from "main" instead, which contained changes that were meant to be deferred until v4.

Revert these changes to prevent these from getting released for now, and so that we can patch v3.4.2 without the breaking changes.