### PR TITLE
ci: create a github release when tags are pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+
+# Only do the release on vx.y.z tags.
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+# We need this to be able to create releases.
+permissions:
+  contents: write
+
+jobs:
+  # The create-release job runs purely to initialize the GitHub release itself,
+  # and names the release after the `x.y.z` tag that was pushed. It's separate
+  # from building the release so that we only create the release once.
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the release version from the tag
+        if: env.VERSION == ''
+        run: |
+          echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "VERSION_NUMBER=$(echo ${{ github.ref_name }} | sed -e s'/^v//')" >> $GITHUB_ENV
+      - name: Show the version
+        run: |
+          echo "VERSION = $VERSION"
+          echo "VERSION_NUMBER = $VERSION_NUMBER"
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$VERSION" --verify-tag --title "$VERSION"
+    outputs:
+      version: ${{ env.VERSION }}
+      version_number: ${{ env.VERSION_NUMBER }}


### PR DESCRIPTION
Closes: #465
Suggested-by: Tomasz Kłoczko @kloczek