### PR TITLE
api: deprecate the jsonpickle.compat module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Upcoming
 ========
     * The unpickler is now more resilient to malformed "py/set" input data.
     * The test suite was updated to leverage more pytest features.
+    * The ``jsonpickle.compat`` module is no longer used. It is still provided
+      for backwards compatibility but it may be removed in a future version.
 
 v4.0.0
 ======

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -1,6 +1,3 @@
-from .compat import string_types
-
-
 class JSONBackend:
     """Manages encoding and decoding using various backends.
 
@@ -172,7 +169,7 @@ class JSONBackend:
         ):
             return False
 
-        if isinstance(loads_exc, string_types):
+        if isinstance(loads_exc, str):
             # This backend's decoder exception is part of the backend
             if not self._store(self._decoder_exceptions, name, mod, loads_exc):
                 return False

--- a/jsonpickle/compat.py
+++ b/jsonpickle/compat.py
@@ -1,3 +1,5 @@
+"""jsonpickle.compat is a deprecated private module and will be removed in the future"""
+
 import queue  # noqa
 import sys
 from collections.abc import Iterator as abc_iterator  # noqa
@@ -13,5 +15,4 @@ ustr = str
 
 
 def iterator(class_):
-    # TODO: Replace all instances of this
     return class_

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -6,7 +6,6 @@ import zlib
 
 import numpy as np
 
-from .. import compat
 from ..compat import numeric_types
 from ..handlers import BaseHandler, register, unregister
 from ..util import b64decode, b64encode
@@ -27,7 +26,7 @@ class NumpyBaseHandler(BaseHandler):
         if hasattr(dtype, 'tostring'):
             data['dtype'] = dtype.tostring()
         else:
-            dtype = compat.ustr(dtype)
+            dtype = str(dtype)
             prefix = '(numpy.record, '
             if dtype.startswith(prefix):
                 dtype = dtype[len(prefix) : -1]

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -7,7 +7,7 @@ import zlib
 import numpy as np
 
 from ..handlers import BaseHandler, register, unregister
-from ..util import NUMERIC_TYPES, b64decode, b64encode
+from ..util import b64decode, b64encode
 
 __all__ = ['register_handlers', 'unregister_handlers']
 
@@ -189,7 +189,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
         if isinstance(values, list):
             # decode text representation
             arr = super().restore(data)
-        elif isinstance(values, NUMERIC_TYPES):
+        elif isinstance(values, (int, float)):
             # single-value array
             arr = np.array([values], dtype=self.restore_dtype(data))
         else:

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -6,9 +6,8 @@ import zlib
 
 import numpy as np
 
-from ..compat import numeric_types
 from ..handlers import BaseHandler, register, unregister
-from ..util import b64decode, b64encode
+from ..util import NUMERIC_TYPES, b64decode, b64encode
 
 __all__ = ['register_handlers', 'unregister_handlers']
 
@@ -190,7 +189,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
         if isinstance(values, list):
             # decode text representation
             arr = super().restore(data)
-        elif isinstance(values, numeric_types):
+        elif isinstance(values, NUMERIC_TYPES):
             # single-value array
             arr = np.array([values], dtype=self.restore_dtype(data))
         else:

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -12,11 +12,12 @@ import array
 import copy
 import datetime
 import io
+import queue
 import re
 import threading
 import uuid
 
-from . import compat, util
+from . import util
 
 
 class Registry:
@@ -224,10 +225,10 @@ class QueueHandler(BaseHandler):
         return data
 
     def restore(self, data):
-        return compat.queue.Queue()
+        return queue.Queue()
 
 
-QueueHandler.handles(compat.queue.Queue)
+QueueHandler.handles(queue.Queue)
 
 
 class CloneFactory:

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -175,7 +175,7 @@ class DatetimeHandler(BaseHandler):
             if hasattr(obj, 'isoformat'):
                 result = obj.isoformat()
             else:
-                result = compat.ustr(obj)
+                result = str(obj)
             return result
         cls, args = obj.__reduce__()
         flatten = pickler.flatten

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -13,7 +13,7 @@ from itertools import chain, islice
 
 from . import handlers, tags, util
 from .backend import json
-from .compat import numeric_types, string_types
+from .compat import numeric_types
 
 
 def encode(
@@ -188,7 +188,7 @@ def _mktyperef(obj):
 
 def _wrap_string_slot(string):
     """Converts __slots__ = 'a' into __slots__ = ('a',)"""
-    if isinstance(string, string_types):
+    if isinstance(string, str):
         return (string,)
     return string
 
@@ -458,7 +458,7 @@ class Pickler:
 
         if self.numeric_keys and isinstance(k, numeric_types):
             pass
-        elif not isinstance(k, string_types):
+        elif not isinstance(k, str):
             try:
                 k = repr(k)
             except Exception:
@@ -593,7 +593,7 @@ class Pickler:
                     # we ignore those
                     pass
 
-            if reduce_val and isinstance(reduce_val, string_types):
+            if reduce_val and isinstance(reduce_val, str):
                 try:
                     varpath = iter(reduce_val.split('.'))
                     # curmod will be transformed by the
@@ -743,7 +743,7 @@ class Pickler:
         """Flatten only non-string key/value pairs"""
         if not util.is_picklable(k, v):
             return data
-        if self.keys and not isinstance(k, string_types):
+        if self.keys and not isinstance(k, str):
             k = self._escape_key(k)
             data[k] = self._flatten(v)
         return data
@@ -753,7 +753,7 @@ class Pickler:
         if not util.is_picklable(k, v):
             return data
         if self.keys:
-            if not isinstance(k, string_types):
+            if not isinstance(k, str):
                 return data
             elif k.startswith(tags.JSON_KEY):
                 k = self._escape_key(k)
@@ -763,7 +763,7 @@ class Pickler:
 
             if self.numeric_keys and isinstance(k, numeric_types):
                 pass
-            elif not isinstance(k, string_types):
+            elif not isinstance(k, str):
                 try:
                     k = repr(k)
                 except Exception:

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -11,7 +11,7 @@ import sys
 import warnings
 from itertools import chain, islice
 
-from . import compat, handlers, tags, util
+from . import handlers, tags, util
 from .backend import json
 from .compat import numeric_types, string_types
 
@@ -462,7 +462,7 @@ class Pickler:
             try:
                 k = repr(k)
             except Exception:
-                k = compat.ustr(k)
+                k = str(k)
 
         data[k] = self._flatten(v)
         return data
@@ -673,7 +673,7 @@ class Pickler:
             if self.unpicklable:
                 data[tags.MODULE] = '{name}/{name}'.format(name=obj.__name__)
             else:
-                data = compat.ustr(obj)
+                data = str(obj)
             return data
 
         if util.is_dictionary_subclass(obj):
@@ -767,7 +767,7 @@ class Pickler:
                 try:
                     k = repr(k)
                 except Exception:
-                    k = compat.ustr(k)
+                    k = str(k)
 
         data[k] = self._flatten(v)
         return data

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -13,7 +13,6 @@ from itertools import chain, islice
 
 from . import handlers, tags, util
 from .backend import json
-from .util import NUMERIC_TYPES
 
 
 def encode(
@@ -377,7 +376,7 @@ class Pickler:
             return self._flatten_bytestring(obj)
 
         # Decimal is a primitive when use_decimal is True
-        if type(obj) in util.PRIMITIVES or (
+        if type(obj) in (str, bool, int, float, type(None)) or (
             self._use_decimal and isinstance(obj, decimal.Decimal)
         ):
             return obj
@@ -456,7 +455,7 @@ class Pickler:
         if k is None:
             k = 'null'  # for compatibility with common json encoders
 
-        if self.numeric_keys and isinstance(k, NUMERIC_TYPES):
+        if self.numeric_keys and isinstance(k, (int, float)):
             pass
         elif not isinstance(k, str):
             try:
@@ -761,7 +760,7 @@ class Pickler:
             if k is None:
                 k = 'null'  # for compatibility with common json encoders
 
-            if self.numeric_keys and isinstance(k, NUMERIC_TYPES):
+            if self.numeric_keys and isinstance(k, (int, float)):
                 pass
             elif not isinstance(k, str):
                 try:

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -13,7 +13,7 @@ from itertools import chain, islice
 
 from . import handlers, tags, util
 from .backend import json
-from .compat import numeric_types
+from .util import NUMERIC_TYPES
 
 
 def encode(
@@ -456,7 +456,7 @@ class Pickler:
         if k is None:
             k = 'null'  # for compatibility with common json encoders
 
-        if self.numeric_keys and isinstance(k, numeric_types):
+        if self.numeric_keys and isinstance(k, NUMERIC_TYPES):
             pass
         elif not isinstance(k, str):
             try:
@@ -761,7 +761,7 @@ class Pickler:
             if k is None:
                 k = 'null'  # for compatibility with common json encoders
 
-            if self.numeric_keys and isinstance(k, numeric_types):
+            if self.numeric_keys and isinstance(k, NUMERIC_TYPES):
                 pass
             elif not isinstance(k, str):
                 try:

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -10,7 +10,7 @@ import warnings
 
 from . import errors, handlers, tags, util
 from .backend import json
-from .compat import numeric_types
+from .util import NUMERIC_TYPES
 
 
 def decode(
@@ -653,7 +653,7 @@ class Unpickler:
             # ignore the reserved attribute
             if ignorereserved and k in tags.RESERVED:
                 continue
-            if isinstance(k, numeric_types):
+            if isinstance(k, NUMERIC_TYPES):
                 str_k = k.__str__()
             else:
                 str_k = k
@@ -868,7 +868,7 @@ class Unpickler:
             for k, v in util.items(obj):
                 if _is_json_key(k):
                     continue
-                if isinstance(k, numeric_types):
+                if isinstance(k, NUMERIC_TYPES):
                     str_k = k.__str__()
                 else:
                     str_k = k
@@ -893,7 +893,7 @@ class Unpickler:
         else:
             # No special keys, thus we don't need to restore the keys either.
             for k, v in util.items(obj):
-                if isinstance(k, numeric_types):
+                if isinstance(k, NUMERIC_TYPES):
                     str_k = k.__str__()
                 else:
                     str_k = k

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -10,7 +10,6 @@ import warnings
 
 from . import errors, handlers, tags, util
 from .backend import json
-from .util import NUMERIC_TYPES
 
 
 def decode(
@@ -653,7 +652,7 @@ class Unpickler:
             # ignore the reserved attribute
             if ignorereserved and k in tags.RESERVED:
                 continue
-            if isinstance(k, NUMERIC_TYPES):
+            if isinstance(k, (int, float)):
                 str_k = k.__str__()
             else:
                 str_k = k
@@ -868,7 +867,7 @@ class Unpickler:
             for k, v in util.items(obj):
                 if _is_json_key(k):
                     continue
-                if isinstance(k, NUMERIC_TYPES):
+                if isinstance(k, (int, float)):
                     str_k = k.__str__()
                 else:
                     str_k = k
@@ -893,7 +892,7 @@ class Unpickler:
         else:
             # No special keys, thus we don't need to restore the keys either.
             for k, v in util.items(obj):
-                if isinstance(k, NUMERIC_TYPES):
+                if isinstance(k, (int, float)):
                     str_k = k.__str__()
                 else:
                     str_k = k

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -8,7 +8,7 @@ import dataclasses
 import sys
 import warnings
 
-from . import compat, errors, handlers, tags, util
+from . import errors, handlers, tags, util
 from .backend import json
 from .compat import numeric_types
 
@@ -115,7 +115,7 @@ def _safe_hasattr(obj, attr):
 
 def _is_json_key(key):
     """Has this key a special object that has been encoded to JSON?"""
-    return isinstance(key, compat.string_types) and key.startswith(tags.JSON_KEY)
+    return isinstance(key, str) and key.startswith(tags.JSON_KEY)
 
 
 class _Proxy:

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -19,12 +19,12 @@ import types
 from collections.abc import Iterator as abc_iterator
 
 from . import tags
-from .compat import numeric_types
 
+NUMERIC_TYPES = (int, float)
 ITERATOR_TYPE = type(iter(''))
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = {list, set, tuple}
-PRIMITIVES = {str, bool, type(None)} | set(numeric_types)
+PRIMITIVES = {str, bool, int, float, type(None)}
 FUNCTION_TYPES = {
     types.FunctionType,
     types.MethodType,

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -20,8 +20,7 @@ from collections.abc import Iterator as abc_iterator
 
 from . import tags
 
-NUMERIC_TYPES = (int, float)
-ITERATOR_TYPE = type(iter(''))
+_ITERATOR_TYPE = type(iter(''))
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = {list, set, tuple}
 PRIMITIVES = {str, bool, int, float, type(None)}
@@ -382,7 +381,7 @@ def is_reducible(obj):
     # Condensing it into one line seems to save the parser a lot of time.
     # fmt: off
     # pylint: disable=line-too-long
-    if type(obj) in NON_REDUCIBLE_TYPES or obj is object or is_dictionary_subclass(obj) or isinstance(obj, types.ModuleType) or is_reducible_sequence_subclass(obj) or is_list_like(obj) or isinstance(getattr(obj, '__slots__', None), ITERATOR_TYPE) or (is_type(obj) and obj.__module__ == 'datetime'):  # noqa: E501
+    if type(obj) in NON_REDUCIBLE_TYPES or obj is object or is_dictionary_subclass(obj) or isinstance(obj, types.ModuleType) or is_reducible_sequence_subclass(obj) or is_list_like(obj) or isinstance(getattr(obj, '__slots__', None), _ITERATOR_TYPE) or (is_type(obj) and obj.__module__ == 'datetime'):  # noqa: E501
         return False
     # fmt: on
     return True

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -17,12 +17,12 @@ import sys
 import time
 import types
 
-from . import compat, tags
+from . import tags
 from .compat import abc_iterator, class_types, iterator_types, numeric_types
 
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = {list, set, tuple}
-PRIMITIVES = {compat.ustr, bool, type(None)} | set(numeric_types)
+PRIMITIVES = {str, bool, type(None)} | set(numeric_types)
 FUNCTION_TYPES = {
     types.FunctionType,
     types.MethodType,
@@ -205,8 +205,8 @@ def is_bytes(obj):
 
 
 def is_unicode(obj):
-    """Helper method to see if the object is a unicode string"""
-    return type(obj) is compat.ustr
+    """DEPRECATED: Helper method to see if the object is a unicode string"""
+    return type(obj) is str
 
 
 def is_tuple(obj):
@@ -574,7 +574,7 @@ def b85decode(payload):
 
 
 def itemgetter(obj, getter=operator.itemgetter(0)):
-    return compat.ustr(getter(obj))
+    return str(getter(obj))
 
 
 def items(obj, exclude=()):

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -19,8 +19,9 @@ import types
 from collections.abc import Iterator as abc_iterator
 
 from . import tags
-from .compat import iterator_types, numeric_types
+from .compat import numeric_types
 
+ITERATOR_TYPE = type(iter(''))
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = {list, set, tuple}
 PRIMITIVES = {str, bool, type(None)} | set(numeric_types)
@@ -381,7 +382,7 @@ def is_reducible(obj):
     # Condensing it into one line seems to save the parser a lot of time.
     # fmt: off
     # pylint: disable=line-too-long
-    if type(obj) in NON_REDUCIBLE_TYPES or obj is object or is_dictionary_subclass(obj) or isinstance(obj, types.ModuleType) or is_reducible_sequence_subclass(obj) or is_list_like(obj) or isinstance(getattr(obj, '__slots__', None), iterator_types) or (is_type(obj) and obj.__module__ == 'datetime'):  # noqa: E501
+    if type(obj) in NON_REDUCIBLE_TYPES or obj is object or is_dictionary_subclass(obj) or isinstance(obj, types.ModuleType) or is_reducible_sequence_subclass(obj) or is_list_like(obj) or isinstance(getattr(obj, '__slots__', None), ITERATOR_TYPE) or (is_type(obj) and obj.__module__ == 'datetime'):  # noqa: E501
         return False
     # fmt: on
     return True

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -16,9 +16,10 @@ import operator
 import sys
 import time
 import types
+from collections.abc import Iterator as abc_iterator
 
 from . import tags
-from .compat import abc_iterator, class_types, iterator_types, numeric_types
+from .compat import iterator_types, numeric_types
 
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = {list, set, tuple}
@@ -65,7 +66,7 @@ def is_type(obj):
     True
     """
     # use "isinstance" and not "is" to allow for metaclasses
-    return isinstance(obj, class_types)
+    return isinstance(obj, type)
 
 
 def has_method(obj, name):


### PR DESCRIPTION
This module is no longer needed now that we're Python 3-only.

Keep the module around for compatibility but remove all internal references.