### PR TITLE
Guard against malformed py/tuple and/or py/iterator data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Upcoming
 ========
-    * The unpickler is now more resilient to malformed "py/set" input data.
+    * The unpickler is now more resilient to malformed "py/set", "py/tuple", and
+      "py/iterator" input data.
     * The test suite was updated to leverage more pytest features.
 
 v4.0.0

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -490,7 +490,10 @@ class Unpickler:
         return parent
 
     def _restore_iterator(self, obj):
-        return iter(self._restore_list(obj[tags.ITERATOR]))
+        try:
+            return iter(self._restore_list(obj[tags.ITERATOR]))
+        except TypeError:
+            return iter([])
 
     def _swapref(self, proxy, instance):
         proxy_id = id(proxy)
@@ -903,7 +906,10 @@ class Unpickler:
         return data
 
     def _restore_tuple(self, obj):
-        return tuple([self._restore(v) for v in obj[tags.TUPLE]])
+        try:
+            return tuple(self._restore(v) for v in obj[tags.TUPLE])
+        except TypeError:
+            return ()
 
     def _restore_tags(self, obj, _passthrough=_passthrough):
         """Return the restoration function for the specified object"""

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -302,6 +302,21 @@ def test_set_with_invalid_data(unpickler):
     assert result == set()
 
 
+def test_tuple_with_invalid_data(unpickler):
+    """Invalid serialized tuple data results in an empty tuple"""
+    data = {tags.TUPLE: 0}
+    result = unpickler.restore(data)
+    assert result == tuple()
+
+
+def test_iterator_with_invalid_data(unpickler):
+    """Invalid serialized iterator data results in an empty iterator"""
+    data = {tags.ITERATOR: set()}
+    result = unpickler.restore(data)
+    with pytest.raises(StopIteration):
+        assert next(result) == set()
+
+
 def test_dict(pickler, unpickler):
     """Our custom keys are preserved when user dicts contain them"""
     dict_a = {'key1': 1.0, 'key2': 20, 'key3': 'thirty', tags.JSON_KEY + '6': 6}


### PR DESCRIPTION
Fix a potential issue with malformed data, should the user decide to manually edit the data or if it gets corrupted. At some point we should probably build a system to try to guess the original object, or as least reconstruct as much of it as possible, but that time is not now as I have a lot of class work.