### PR TITLE
unpickler: guard against malformed py/reduce values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Upcoming
 ========
-    * The unpickler is now more resilient to malformed "py/set", "py/tuple", and
-      "py/iterator" input data.
+    * The unpickler is now more resilient to malformed "py/reduce", "py/set",
+      "py/tuple", and "py/iterator" input data. (+544)
     * The test suite was updated to leverage more pytest features.
     * The ``jsonpickle.compat`` module is no longer used. It is still provided
       for backwards compatibility but it may be removed in a future version.

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -513,7 +513,13 @@ class Unpickler:
         """
         proxy = _Proxy()
         self._mkref(proxy)
-        reduce_val = list(map(self._restore, obj[tags.REDUCE]))
+        try:
+            reduce_val = list(map(self._restore, obj[tags.REDUCE]))
+        except TypeError:
+            result = []
+            proxy.reset(result)
+            self._swapref(proxy, result)
+            return result
         if len(reduce_val) < 5:
             reduce_val.extend([None] * (5 - len(reduce_val)))
         f, args, state, listitems, dictitems = reduce_val
@@ -525,6 +531,11 @@ class Unpickler:
                 cls = self._restore(cls)
             stage1 = cls.__new__(cls, *args[1:])
         else:
+            if not callable(f):
+                result = []
+                proxy.reset(result)
+                self._swapref(proxy, result)
+                return result
             stage1 = f(*args)
 
         if state:

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -317,6 +317,14 @@ def test_iterator_with_invalid_data(unpickler):
         assert next(result) == set()
 
 
+@pytest.mark.parametrize('value', ['', 0, True, None, [], {}, ('x',), {'x': True}])
+def test_reduce_with_invalid_data(value, unpickler):
+    """Invalid serialized reduce data results in an empty list"""
+    data = {tags.REDUCE: value}
+    result = unpickler.restore(data)
+    assert result == []
+
+
 def test_dict(pickler, unpickler):
     """Our custom keys are preserved when user dicts contain them"""
     dict_a = {'key1': 1.0, 'key2': 20, 'key3': 'thirty', tags.JSON_KEY + '6': 6}


### PR DESCRIPTION
The stored value may not be iterable. Restore to an empty list when invalid py/reduce contents are encountered.