### PR TITLE
backend: make the yaml backend opt-in

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Upcoming
+========
+    * **Breaking Change**: The ``yaml`` module is no longer registered by default.
+      You can re-enable yaml support using ``jsonpickle.ext.yaml.register()``.
+      (#550) (+551)
+
 v4.0.2
 ======
     * The unpickler is now more resilient to malformed "py/id" and "py/repr" data.

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -92,9 +92,6 @@ class JSONBackend:
         self.load_backend('simplejson')
         self.load_backend('json')
         self.load_backend('ujson')
-        self.load_backend(
-            'yaml', dumps='dump', loads='safe_load', loads_exc='YAMLError'
-        )
 
         # Defaults for various encoders
         json_opts = ((), {'sort_keys': False})

--- a/jsonpickle/ext/yaml.py
+++ b/jsonpickle/ext/yaml.py
@@ -1,0 +1,15 @@
+"""YAML extension for jsonpickle
+
+The YAML extension module connects jsonpickle to the PyYAML `yaml` module.
+"""
+
+from ..backend import json as jsonpickle_backend
+
+
+def register(backend=None):
+    """Register the yaml module with jsonpickle's JSONBackend"""
+    if backend is None:
+        backend = jsonpickle_backend
+    return backend.load_backend(
+        'yaml', dumps='dump', loads='safe_load', loads_exc='YAMLError'
+    )

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -6,6 +6,7 @@ import pytest
 from helper import SkippableTest
 
 import jsonpickle
+import jsonpickle.ext.yaml
 
 
 class Thing:
@@ -174,6 +175,7 @@ class UJsonTestCase(BackendBase):
 
 class YamlTestCase(BackendBase):
     def setUp(self):
+        jsonpickle.ext.yaml.register()
         self.set_preferred_backend('yaml')
 
     def test_backend(self):


### PR DESCRIPTION
YAML is a much more lenient format so it can cause jsonpickle to load files that are expected to fail when interpreted using a JSON reader. Let users control whether or not the yaml backend is used.

Move registration of the yaml backend into a separate jsonpickle.ext.yaml module. Do not register the yaml module by default so that users can opt-in to it.

Closes: #550
Reported-by: Jason R. Coombs @jaraco