### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jsonpickle"
+license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Theelx" },
     { name = "David Aguilar", email = "davvid+jsonpickle@gmail.com" },


### PR DESCRIPTION
Followup to #558

Unfortunately, removing the license classifier in https://github.com/jsonpickle/jsonpickle/commit/ae9505871a92a0b7595687b677d1b9b25df45e58 means that PyPI won't show any license information anymore. Ideally it should not be removed until the PEP 639 syntax with license expression is adopted. This was only added in setuptools `77.0.3` which requires Python 3.9, so sadly incompatible at the moment.

I'd suggest to use the SPDX license identifier with the legacy `project.license.text` field instead, until Python 3.8 is dropped. _Note that this will emit a DeprecationWarning until then, probably something which should be relaxed in setuptools._

https://spdx.org/licenses/BSD-3-Clause.html

/CC @davvid

| before (4.0.3) | after (4.0.4) |
| ------ | ----- |
| <img width="282" alt="Screenshot 2025-03-29 at 16 09 42" src="https://github.com/user-attachments/assets/83158748-39bd-4eea-b983-ad291362def3" /> | <img width="288" alt="Screenshot 2025-03-29 at 16 10 04" src="https://github.com/user-attachments/assets/bb6f441c-38c5-434a-9423-cdd57fbe648b" /> |
