### PR TITLE
Fix test_multindex_dataframe_roundtrip on 32-bit architectures

### DIFF
--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -99,7 +99,7 @@ def test_multindex_dataframe_roundtrip():
     df = pd.DataFrame(
         {
             'idx_lvl0': ['a', 'b', 'c'],
-            'idx_lvl1': np.int_([1, 1, 2]),
+            'idx_lvl1': np.int64([1, 1, 2]),
             'an_int': np.int_([1, 2, 3]),
             'a_float': np.float64([2.5, 3.5, 4.5]),
             'a_nan': np.array([np.nan] * 3),


### PR DESCRIPTION
https://bugs.debian.org/1103146 reports that this test is failing on Debian's i386 architecture, and
https://ci.debian.net/packages/j/jsonpickle/testing/armel/, https://ci.debian.net/packages/j/jsonpickle/testing/armhf/, and https://ci.debian.net/packages/j/jsonpickle/testing/i386/ show that it has been failing on all 32-bit architectures for some time.  The reason is buried many levels deep, but it turns out that
`pandas.core.indexes.base.Index._with_infer` converts the index levels to `np.int64` even if they were initially of a narrower integer type - so it seems to make most sense to start them out as `np.int64` as well.