### PR TITLE
Fix legacy pandas dataframe decoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Upcoming
       You can re-enable yaml support using ``jsonpickle.ext.yaml.register()``.
       (#550) (+551)
 
+v4.1.1
+======
+    * An error in the jsonpickle pandas extension when decoding objects that were encoded
+      before jsonpickle v3.4.0 was fixed, and warnings were added. (+562)
+
 v4.1.0
 ======
     * Deprecation warnings were added to certain simple functions in ``jsonpickle/util.py``.

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -329,3 +329,20 @@ def test_multilevel_columns():
     assert data_frame.columns.names == cloned_data_frame.columns.names
     assert_frame_equal(data_frame, cloned_data_frame)
     assert names == cloned_data_frame.columns.names
+
+
+def test_pre_v3_4_df_decoding():
+    df = pd.DataFrame(
+        {
+            'category': ['a', 'b'],
+            'value': [1, 2],
+        }
+    )
+    # the encoded df has to be manually stored unless we want to make it install jsonpickle 3.3
+    # then encode and store the object, then reinstall the latest jsonpickle
+    encoded_df = r'{"py/object": "pandas.core.frame.DataFrame", "values": "category,value\na,1\nb,2\n", "txt": true, "meta": {"dtypes": {"category": "object", "value": "int64"}, "index": "{\"py/object\": \"pandas.core.indexes.range.RangeIndex\", \"values\": \"[0, 1]\", \"txt\": true, \"meta\": {\"dtype\": \"int64\", \"name\": null}}", "column_level_names": [null], "header": [0]}}'
+    # assert that decoding this raises a UserWarning
+    with pytest.warns(UserWarning):
+        new_df = jsonpickle.loads(encoded_df)
+
+    assert_frame_equal(new_df, df)


### PR DESCRIPTION
This fixes an issue I discovered when typing the pandas extension where we'd get a JSONDecodeError on PandasDfHandler's restore. I also added a warning and a test, and this test adds coverage for the make_read_csv_params function (which was previously untested). The make_read_csv_params function is only used for the pre-3.4 decoding though, so it's just a nice-to-have in terms of coverage rather than essential, because the restore_v3_3 function (which is the only caller for make_read_csv_params) should never change anymore. This should be released in its own 4.1.1 release if approved by @davvid (I would appreciate if you could do the release davvid).

One thing I'm considering is whether the two neighboring try/excepts should be merged, the only issue I can think of though would be the loss of specificity for the error messages (as to whether we know they're decoding a pre-3.4 object or not). Not sure how big of a deal this would be, but I'm leaving it separate for now.