### PR TITLE
V5: Add type hints, drop support, remove functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.python-version }}-v1-
 
-      - name: Install dependencies
+      - name: Install tox dependencies
         run: |
           python -m pip install -U pip
           python -m pip install -U "tox>=4"
@@ -51,3 +51,11 @@ jobs:
       - name: Tox tests
         run: |
           tox run
+
+      - name: Install mypy dependencies
+        run: |
+          python -m pip install -U .[testing]
+
+      - name: Mypy tests
+        run: |
+          mypy ./jsonpickle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
 
     steps:
@@ -43,7 +43,7 @@ jobs:
           python -m pip install -U "tox>=4"
 
       - name: Install gmpy2 dependencies
-        if: matrix.python-version == '3.11' || matrix.python-version == '3.12'
+        if: matrix.python-version == '3.11' || matrix.python-version == '3.12' || matrix.python-version == '3.13'
         run: |
           sudo apt-get -y update
           sudo apt-get install -y libmpfr-dev libmpc-dev

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ perf.svg
 fuzz_*.pkg.spec
 *.dict
 monkeytype.sqlite3
+# pyenv files
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ fuzz_*.pkg.spec
 monkeytype.sqlite3
 # pyenv files
 .python-version
+# type checking config
+.pyre*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,22 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 25.1.0
   hooks:
   - id: black
+    args:
+      - --skip-string-normalization
+      - --target-version=py39
+      - jsonpickle tests fuzzing/fuzz-targets
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.4.0
+  rev: v1.12.1
   hooks:
   - id: blacken-docs
+
+- repo: https://github.com/pycqa/isort
+  rev: 6.0.1
+  hooks:
+  - id: isort
+    args:
+      - --profile=black
+      - jsonpickle tests fuzzing/fuzz-targets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     args:
       - --skip-string-normalization
       - --target-version=py39
-      - jsonpickle tests fuzzing/fuzz-targets
 
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.12.1
@@ -19,4 +18,3 @@ repos:
   - id: isort
     args:
       - --profile=black
-      - jsonpickle tests fuzzing/fuzz-targets

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,16 @@
-Upcoming
+v5.0.0
 ========
     * **Breaking Change**: The ``yaml`` module is no longer registered by default.
       You can re-enable yaml support using ``jsonpickle.ext.yaml.register()``.
       (#550) (+551)
+    * **Breaking Change**: Support for CPython 3.7 and 3.8 was dropped, and support for
+      CPython 3.13 was added. (#561)
+    * **Breaking Change**: Changed ``is_*`` functions in jsonpickle.util to the private API
+      rather than the public one by adding a single underscore to their names.
+    * **Breaking Change**: Removed the deprecated functions deprecated in 4.1.0 with commit
+      59dda25. Additionally, ``util.is_sequence`` was removed due to having only one caller,
+      ``util.is_sequence_subclass``.
+    * Mypy-compatible typing has been added to the entire jsonpickle public API! (#561)
 
 v4.1.1
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 v5.0.0
-========
+======
     * **Breaking Change**: The ``yaml`` module is no longer registered by default.
       You can re-enable yaml support using ``jsonpickle.ext.yaml.register()``.
       (#550) (+551)

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,18 @@
-collect_ignore = ['contrib', 'examples']
+import sys
+from pathlib import Path
+
+collect_ignore = ['contrib', 'examples', 'build']
+
+
+def pytest_ignore_collect(path, config):
+    p = Path(path)
+    if any(directory in p.parts for directory in collect_ignore):
+        return True
+    # atheris isn't available on python 3.13+, so we disable fuzzing when that's the case
+    if sys.version_info >= (3, 13):
+        if "fuzzing" in p.parts:
+            return True
+    return False
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -4,8 +4,8 @@ from pathlib import Path
 collect_ignore = ['contrib', 'examples', 'build']
 
 
-def pytest_ignore_collect(path, config):
-    p = Path(path)
+def pytest_ignore_collect(collection_path, config):
+    p = Path(collection_path)
     if any(directory in p.parts for directory in collect_ignore):
         return True
     # atheris isn't available on python 3.13+, so we disable fuzzing when that's the case

--- a/garden.yaml
+++ b/garden.yaml
@@ -34,7 +34,7 @@ trees:
         ${activate} python3 -m sphinx docs pages
       fmt: |
         ${activate}
-        black --skip-string-normalization --target-version py38 "$@" jsonpickle tests fuzzing/fuzz-targets
+        black --skip-string-normalization --target-version py39 "$@" jsonpickle tests fuzzing/fuzz-targets
         isort --profile=black "$@" jsonpickle tests fuzzing/fuzz-targets
       setup: |
         test -d env3 || python3 -m venv env3

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -1,3 +1,7 @@
+from types import ModuleType
+from typing import Any, Dict, Optional, Type, Union
+
+
 class JSONBackend:
     """Manages encoding and decoding using various backends.
 
@@ -9,13 +13,15 @@ class JSONBackend:
 
     """
 
-    def _verify(self):
+    def _verify(self) -> None:
         """Ensures that we've loaded at least one JSON backend."""
         if self._verified:
             return
         raise AssertionError('jsonpickle could not load any json modules')
 
-    def encode(self, obj, indent=None, separators=None):
+    def encode(
+        self, obj: Any, indent: Optional[int] = None, separators: Optional[Any] = None
+    ) -> str:
         """
         Attempt to encode an object into JSON.
 
@@ -41,7 +47,7 @@ class JSONBackend:
     # def dumps
     dumps = encode
 
-    def decode(self, string):
+    def decode(self, string: str) -> Any:
         """
         Attempt to decode an object from a JSON string.
 
@@ -67,7 +73,7 @@ class JSONBackend:
     # def loads
     loads = decode
 
-    def __init__(self, fallthrough=True):
+    def __init__(self, fallthrough: bool = True) -> None:
         # Whether we should fallthrough to the next backend
         self._fallthrough = fallthrough
         # The names of backends that have been successfully imported
@@ -102,7 +108,7 @@ class JSONBackend:
             'django.util.simplejson': json_opts,
         }
 
-    def enable_fallthrough(self, enable):
+    def enable_fallthrough(self, enable: bool) -> None:
         """
         Disable jsonpickle's fallthrough-on-error behavior
 
@@ -119,7 +125,7 @@ class JSONBackend:
         """
         self._fallthrough = enable
 
-    def _store(self, dct, backend, obj, name):
+    def _store(self, dct: Dict[str, Any], backend: str, obj: ModuleType, name: str):
         try:
             dct[backend] = getattr(obj, name)
         except AttributeError:
@@ -127,7 +133,13 @@ class JSONBackend:
             return False
         return True
 
-    def load_backend(self, name, dumps='dumps', loads='loads', loads_exc=ValueError):
+    def load_backend(
+        self,
+        name: str,
+        dumps: str = 'dumps',
+        loads: str = 'loads',
+        loads_exc: Union[str, Type[Exception]] = ValueError,
+    ) -> bool:
         """Load a JSON backend by name.
 
         This method loads a backend and sets up references to that
@@ -185,7 +197,7 @@ class JSONBackend:
         self._verified = True
         return True
 
-    def remove_backend(self, name):
+    def remove_backend(self, name: str) -> None:
         """Remove all entries for a particular backend."""
         self._encoders.pop(name, None)
         self._decoders.pop(name, None)
@@ -196,7 +208,13 @@ class JSONBackend:
             self._backend_names.remove(name)
         self._verified = bool(self._backend_names)
 
-    def backend_encode(self, name, obj, indent=None, separators=None):
+    def backend_encode(
+        self,
+        name: str,
+        obj: Any,
+        indent: Optional[int] = None,
+        separators: Optional[str] = None,
+    ):
         optargs, optkwargs = self._encoder_options.get(name, ([], {}))
         encoder_kwargs = optkwargs.copy()
         if indent is not None:
@@ -206,12 +224,12 @@ class JSONBackend:
         encoder_args = (obj,) + tuple(optargs)
         return self._encoders[name](*encoder_args, **encoder_kwargs)
 
-    def backend_decode(self, name, string):
+    def backend_decode(self, name: str, string: str) -> Any:
         optargs, optkwargs = self._decoder_options.get(name, ((), {}))
         decoder_kwargs = optkwargs.copy()
         return self._decoders[name](string, *optargs, **decoder_kwargs)
 
-    def set_preferred_backend(self, name):
+    def set_preferred_backend(self, name: str) -> None:
         """
         Set the preferred json backend.
 
@@ -236,7 +254,7 @@ class JSONBackend:
             errmsg = 'The "%s" backend has not been loaded.' % name
             raise AssertionError(errmsg)
 
-    def set_encoder_options(self, name, *args, **kwargs):
+    def set_encoder_options(self, name: str, *args: Any, **kwargs: Any) -> None:
         """
         Associate encoder-specific options with an encoder.
 
@@ -257,7 +275,7 @@ class JSONBackend:
         """
         self._encoder_options[name] = (args, kwargs)
 
-    def set_decoder_options(self, name, *args, **kwargs):
+    def set_decoder_options(self, name: str, *args: Any, **kwargs: Any) -> None:
         """
         Associate decoder-specific options with a decoder.
 

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -187,7 +187,7 @@ class JSONBackend:
             self._decoder_exceptions[name] = loads_exc
 
         # Setup the default args and kwargs for this encoder/decoder
-        self._encoder_options.setdefault(name, ([], {}))
+        self._encoder_options.setdefault(name, ([], {}))  # type: ignore
         self._decoder_options.setdefault(name, ([], {}))
 
         # Add this backend to the list of candidate backends

--- a/jsonpickle/backend.py
+++ b/jsonpickle/backend.py
@@ -218,9 +218,9 @@ class JSONBackend:
         optargs, optkwargs = self._encoder_options.get(name, ([], {}))
         encoder_kwargs = optkwargs.copy()
         if indent is not None:
-            encoder_kwargs['indent'] = indent
+            encoder_kwargs['indent'] = indent  # type: ignore[assignment]
         if separators is not None:
-            encoder_kwargs['separators'] = separators
+            encoder_kwargs['separators'] = separators  # type: ignore[assignment]
         encoder_args = (obj,) + tuple(optargs)
         return self._encoders[name](*encoder_args, **encoder_kwargs)
 

--- a/jsonpickle/errors.py
+++ b/jsonpickle/errors.py
@@ -2,7 +2,9 @@
 Stores custom jsonpickle errors.
 """
 
+from typing import Any, Dict
+
 
 class ClassNotFoundError(BaseException):
-    def __init__(*args, **kwargs):
+    def __init__(*args, **kwargs: Dict[str, Any]):
         pass

--- a/jsonpickle/ext/gmpy.py
+++ b/jsonpickle/ext/gmpy.py
@@ -3,25 +3,27 @@ try:
 except ImportError:
     gmpy = None
 
-from ..handlers import BaseHandler, register, unregister
+from typing import Any, Dict
+
+from ..handlers import BaseHandler, HandlerReturn, register, unregister
 
 __all__ = ['register_handlers', 'unregister_handlers']
 
 
 class GmpyMPZHandler(BaseHandler):
-    def flatten(self, obj, data):
+    def flatten(self, obj: gmpy.mpz, data: Dict[str, Any]) -> HandlerReturn:
         data['int'] = int(obj)
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> gmpy.mpz:
         return gmpy.mpz(data['int'])
 
 
-def register_handlers():
+def register_handlers() -> None:
     if gmpy is not None:
         register(gmpy.mpz, GmpyMPZHandler, base=True)
 
 
-def unregister_handlers():
+def unregister_handlers() -> None:
     if gmpy is not None:
         unregister(gmpy.mpz)

--- a/jsonpickle/ext/gmpy.py
+++ b/jsonpickle/ext/gmpy.py
@@ -1,5 +1,5 @@
 try:
-    import gmpy2 as gmpy
+    import gmpy2 as gmpy  # type: ignore[import-untyped]
 except ImportError:
     gmpy = None
 

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -1,27 +1,44 @@
+from __future__ import annotations
+
 import ast
 import json
 import sys
 import warnings
 import zlib
+from types import ModuleType
+from typing import Any, Dict, Tuple
 
 import numpy as np
+
+# do the annotations import so python doesn't complain about numpy type hints missing if numpy isn't installed
+
+
+_np_version: Tuple[int, ...] = tuple(int(x) for x in np.__version__.split('.')[:3])
+# numpy.typing was introduced in 1.20.0
+if _np_version >= (1, 20, 0):
+    from numpy.typing import ArrayLike, DTypeLike, NDArray
+else:
+    NDArray = Any
+    ArrayLike = Any
+    DTypeLike = Any
+
 
 from ..handlers import BaseHandler, register, unregister
 from ..util import b64decode, b64encode
 
 __all__ = ['register_handlers', 'unregister_handlers']
 
-native_byteorder = '<' if sys.byteorder == 'little' else '>'
+native_byteorder: str = '<' if sys.byteorder == 'little' else '>'
 
 
-def get_byteorder(arr):
+def get_byteorder(arr: ArrayLike) -> str:
     """translate equals sign to native order"""
     byteorder = arr.dtype.byteorder
     return native_byteorder if byteorder == '=' else byteorder
 
 
 class NumpyBaseHandler(BaseHandler):
-    def flatten_dtype(self, dtype, data):
+    def flatten_dtype(self, dtype: DTypeLike, data: Dict[str, Any]) -> None:
         if hasattr(dtype, 'tostring'):
             data['dtype'] = dtype.tostring()
         else:
@@ -31,7 +48,7 @@ class NumpyBaseHandler(BaseHandler):
                 dtype = dtype[len(prefix) : -1]
             data['dtype'] = dtype
 
-    def restore_dtype(self, data):
+    def restore_dtype(self, data: Dict[str, Any]) -> DTypeLike:
         dtype = data['dtype']
         if dtype.startswith(('{', '[')):
             dtype = ast.literal_eval(dtype)
@@ -39,21 +56,21 @@ class NumpyBaseHandler(BaseHandler):
 
 
 class NumpyDTypeHandler(NumpyBaseHandler):
-    def flatten(self, obj, data):
+    def flatten(self, obj: DTypeLike, data: Dict[str, Any]) -> Dict[str, Any]:
         self.flatten_dtype(obj, data)
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> DTypeLike:
         return self.restore_dtype(data)
 
 
 class NumpyGenericHandler(NumpyBaseHandler):
-    def flatten(self, obj, data):
+    def flatten(self, obj: ArrayLike, data: Dict[str, Any]) -> Dict[str, Any]:
         self.flatten_dtype(obj.dtype.newbyteorder('N'), data)
         data['value'] = self.context.flatten(obj.tolist(), reset=False)
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> Dict[str, Any]:
         value = self.context.restore(data['value'], reset=False)
         return self.restore_dtype(data).type(value)
 
@@ -61,7 +78,7 @@ class NumpyGenericHandler(NumpyBaseHandler):
 class NumpyDatetimeHandler(NumpyGenericHandler):
     """Extend NumpyGenericHandler to handle nanosecond-resolution datetime64"""
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> Dict[str, Any]:
         value = self.context.restore(data['value'], reset=False)
         dtype = data['dtype']
         if dtype.endswith('[ns]'):
@@ -75,28 +92,29 @@ class UnpickleableNumpyGenericHandler(NumpyGenericHandler):
     when unpicklable=False (the default is True).
     """
 
-    def flatten(self, obj, data):
+    # TODO: narrow return value down from Any
+    def flatten(self, obj: ArrayLike, data: Dict[str, Any]) -> Any:
         if not self.context.unpicklable:
             return self.context.flatten(obj.tolist(), reset=False)
         else:
             return super(NumpyGenericHandler, self).flatten(obj, data)
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]):
         raise NotImplementedError
 
 
 class NumpyNDArrayHandler(NumpyBaseHandler):
     """Stores arrays as text representation, without regard for views"""
 
-    def flatten_flags(self, obj, data):
+    def flatten_flags(self, obj: NDArray, data: Dict[str, Any]) -> None:
         if obj.flags.writeable is False:
             data['writeable'] = False
 
-    def restore_flags(self, data, arr):
+    def restore_flags(self, data: Dict[str, Any], arr: NDArray) -> None:
         if not data.get('writeable', True):
             arr.flags.writeable = False
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: NDArray, data: Dict[str, Any]) -> Dict[str, Any]:
         self.flatten_dtype(obj.dtype.newbyteorder('N'), data)
         self.flatten_flags(obj, data)
         data['values'] = self.context.flatten(obj.tolist(), reset=False)
@@ -106,7 +124,7 @@ class NumpyNDArrayHandler(NumpyBaseHandler):
             data['shape'] = obj.shape
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> NDArray:
         values = self.context.restore(data['values'], reset=False)
         arr = np.array(
             values, dtype=self.restore_dtype(data), order=data.get('order', 'C')
@@ -129,7 +147,9 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
     that would be less language-agnostic
     """
 
-    def __init__(self, size_threshold=16, compression=zlib):
+    def __init__(
+        self, size_threshold: int = 16, compression: ModuleType = zlib
+    ) -> None:
         """
         :param size_threshold: nonnegative int or None
             valid values for 'size_threshold' are all nonnegative
@@ -142,17 +162,17 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
         self.size_threshold = size_threshold
         self.compression = compression
 
-    def flatten_byteorder(self, obj, data):
+    def flatten_byteorder(self, obj: NDArray, data: Dict[str, Any]) -> None:
         byteorder = obj.dtype.byteorder
         if byteorder != '|':
             data['byteorder'] = get_byteorder(obj)
 
-    def restore_byteorder(self, data, arr):
+    def restore_byteorder(self, data: Dict[str, Any], arr: NDArray) -> None:
         byteorder = data.get('byteorder', None)
         if byteorder:
             arr.dtype = arr.dtype.newbyteorder(byteorder)
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: NDArray, data: Dict[str, Any]) -> Dict[str, Any]:
         """encode numpy to json"""
         if self.size_threshold is None or self.size_threshold >= obj.size:
             # encode as text
@@ -194,7 +214,7 @@ class NumpyNDArrayHandlerBinary(NumpyNDArrayHandler):
 
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> NDArray:
         """decode numpy from json"""
         values = data['values']
         if isinstance(values, list):
@@ -252,7 +272,12 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
     implement is correctly reproduced.
     """
 
-    def __init__(self, mode='warn', size_threshold=16, compression=zlib):
+    def __init__(
+        self,
+        mode: str = 'warn',
+        size_threshold: int = 16,
+        compression: ModuleType = zlib,
+    ) -> None:
         """
         :param mode: {'warn', 'raise', 'ignore'}
             How to react when encountering array-like objects whose
@@ -268,7 +293,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
         super().__init__(size_threshold, compression)
         self.mode = mode
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: NDArray, data: Dict[str, Any]) -> Dict[str, Any]:
         """encode numpy to json"""
         base = obj.base
         if base is None and obj.flags.forc:
@@ -322,7 +347,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
 
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> NDArray:
         """decode numpy from json"""
         base = data.get('base', None)
         if base is None:
@@ -352,10 +377,10 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
 
 
 def register_handlers(
-    ndarray_mode='warn',
-    ndarray_size_threshold=16,
-    ndarray_compression=zlib,
-):
+    ndarray_mode: str = 'warn',
+    ndarray_size_threshold: int = 16,
+    ndarray_compression: ModuleType = zlib,
+) -> None:
     """Register handlers for numpy types
 
     :param ndarray_abc_xyz: Forward constructor arguments to NumpyNDArrayHandlerView.
@@ -378,7 +403,7 @@ def register_handlers(
     register(np.datetime64, NumpyDatetimeHandler, base=True)
 
 
-def unregister_handlers():
+def unregister_handlers() -> None:
     """Remove numpy handlers from the handler registry"""
     unregister(np.dtype)
     unregister(np.generic)

--- a/jsonpickle/ext/pandas.py
+++ b/jsonpickle/ext/pandas.py
@@ -166,9 +166,9 @@ class PandasDfHandler(BaseHandler):
             columns: Union[List[Tuple[Any, ...]], List[str]] = [
                 tuple(col) for col in obj.columns
             ]
-            column_names: Union[List[List[object]], List[Hashable], Hashable] = (
-                obj.columns.names
-            )
+            column_names: Union[
+                List[List[object]], List[Hashable], List[str], Hashable
+            ] = obj.columns.names
             is_multicolumns = True
         else:
             columns = obj.columns.tolist()
@@ -178,7 +178,7 @@ class PandasDfHandler(BaseHandler):
         # handle multiindex index
         if isinstance(obj.index, pd.MultiIndex):
             index_values = [tuple(idx) for idx in obj.index.values]
-            index_names: Union[List[Hashable], Hashable] = obj.index.names
+            index_names: Union[List[Hashable], List[str], Hashable] = obj.index.names
             is_multiindex = True
         else:
             index_values = obj.index.tolist()

--- a/jsonpickle/ext/yaml.py
+++ b/jsonpickle/ext/yaml.py
@@ -3,10 +3,13 @@
 The YAML extension module connects jsonpickle to the PyYAML `yaml` module.
 """
 
+from typing import Optional
+
+from ..backend import JSONBackend
 from ..backend import json as jsonpickle_backend
 
 
-def register(backend=None):
+def register(backend: Optional[JSONBackend] = None) -> bool:
     """Register the yaml module with jsonpickle's JSONBackend"""
     if backend is None:
         backend = jsonpickle_backend

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -23,7 +23,7 @@ from . import util
 T = TypeVar("T")
 # we can't import the below types directly from pickler/unpickler because we'd get a circular import
 ContextType = Union[  # type: ignore[valid-type]
-    TypeVar("Pickler", bound="Pickler"),
+    TypeVar("Pickler", bound="Pickler"),  # noqa: F821
     TypeVar("Unpickler", bound="Unpickler"),  # noqa: F821
 ]
 HandlerType = Type[Any]
@@ -49,7 +49,7 @@ class Registry:
         """
         handler = self._handlers.get(cls_or_name)
         # attempt to find a base class
-        if handler is None and util.is_type(cls_or_name):
+        if handler is None and util._is_type(cls_or_name):
             for cls, base_handler in self._base_handlers.items():
                 if issubclass(cls_or_name, cls):
                     return base_handler
@@ -81,7 +81,7 @@ class Registry:
                 return handler_cls
 
             return _register
-        if not util.is_type(cls):
+        if not util._is_type(cls):
             raise TypeError(f'{cls!r} is not a class/type')
         # store both the name and the actual type for the ugly cases like
         # _sre.SRE_Pattern that cannot be loaded back directly

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -16,16 +16,23 @@ import queue
 import re
 import threading
 import uuid
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from . import util
 
+T = TypeVar("T")
+HandlerType = Type[Any]
+KeyType = Union[Type[Any], str]
+HandlerReturn = Union[Dict[str, Any], str]
+DateTime = Union[datetime.datetime, datetime.date, datetime.time]
+
 
 class Registry:
-    def __init__(self):
+    def __init__(self) -> None:
         self._handlers = {}
         self._base_handlers = {}
 
-    def get(self, cls_or_name, default=None):
+    def get(self, cls_or_name: KeyType, default: Any = None) -> Any:
         """
         :param cls_or_name: the type or its fully qualified name
         :param default: default value, if a matching handler is not found
@@ -43,7 +50,9 @@ class Registry:
                     return base_handler
         return default if handler is None else handler
 
-    def register(self, cls, handler=None, base=False):
+    def register(
+        self, cls: Type[Any], handler: KeyType = None, base: bool = False
+    ) -> Optional[Callable[[HandlerType], HandlerType]]:
         """Register the a custom handler for a class
 
         :param cls: The custom object class to handle
@@ -76,7 +85,7 @@ class Registry:
             # only store the actual type for subclass checking
             self._base_handlers[cls] = handler
 
-    def unregister(self, cls):
+    def unregister(self, cls: Type[Any]) -> None:
         self._handlers.pop(cls, None)
         self._handlers.pop(util.importable_name(cls), None)
         self._base_handlers.pop(cls, None)
@@ -89,7 +98,7 @@ get = registry.get
 
 
 class BaseHandler:
-    def __init__(self, context):
+    def __init__(self, context: Any):
         """
         Initialize a new handler to handle a registered type.
 
@@ -99,7 +108,7 @@ class BaseHandler:
         """
         self.context = context
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: Any, data: Dict[str, Any]) -> HandlerReturn:
         """
         Flatten `obj` into a json-friendly form and write result to `data`.
 
@@ -110,7 +119,7 @@ class BaseHandler:
         """
         raise NotImplementedError('You must implement flatten() in %s' % self.__class__)
 
-    def restore(self, obj):
+    def restore(self, obj: Any) -> Any:
         """
         Restore an object of the registered type from the json-friendly
         representation `obj` and return it.
@@ -118,7 +127,7 @@ class BaseHandler:
         raise NotImplementedError('You must implement restore() in %s' % self.__class__)
 
     @classmethod
-    def handles(self, cls):
+    def handles(self, cls: Type[Any]) -> Type[Any]:
         """
         Register this handler for the given class. Suitable as a decorator,
         e.g.::
@@ -131,7 +140,8 @@ class BaseHandler:
         registry.register(cls, self)
         return cls
 
-    def __call__(self, context):
+    #
+    def __call__(self, context: Any) -> "BaseHandler":
         """This permits registering either Handler instances or classes
 
         :Parameters:
@@ -144,12 +154,12 @@ class BaseHandler:
 class ArrayHandler(BaseHandler):
     """Flatten and restore array.array objects"""
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: array.array, data: Dict[str, Any]) -> HandlerReturn:
         data['typecode'] = obj.typecode
         data['values'] = self.context.flatten(obj.tolist(), reset=False)
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> array.array:
         typecode = data['typecode']
         values = self.context.restore(data['values'], reset=False)
         if typecode == 'c':
@@ -169,7 +179,7 @@ class DatetimeHandler(BaseHandler):
 
     """
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: DateTime, data: Dict[str, Any]) -> HandlerReturn:
         pickler = self.context
         if not pickler.unpicklable:
             if hasattr(obj, 'isoformat'):
@@ -184,7 +194,7 @@ class DatetimeHandler(BaseHandler):
         data['__reduce__'] = (flatten(cls, reset=False), args)
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> DateTime:
         cls, args = data['__reduce__']
         unpickler = self.context
         restore = unpickler.restore
@@ -202,11 +212,11 @@ DatetimeHandler.handles(datetime.time)
 class RegexHandler(BaseHandler):
     """Flatten _sre.SRE_Pattern (compiled regex) objects"""
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: re.Pattern, data: Dict[str, Any]) -> HandlerReturn:
         data['pattern'] = obj.pattern
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> re.Pattern:
         return re.compile(data['pattern'])
 
 
@@ -221,10 +231,10 @@ class QueueHandler(BaseHandler):
 
     """
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: queue.Queue, data: Dict[str, Any]) -> HandlerReturn:
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> queue.Queue:
         return queue.Queue()
 
 
@@ -234,25 +244,25 @@ QueueHandler.handles(queue.Queue)
 class CloneFactory:
     """Serialization proxy for collections.defaultdict's default_factory"""
 
-    def __init__(self, exemplar):
+    def __init__(self, exemplar: T) -> None:
         self.exemplar = exemplar
 
-    def __call__(self, clone=copy.copy):
+    def __call__(self, clone: Callable[[T], T] = copy.copy) -> T:
         """Create new instances by making copies of the provided exemplar"""
         return clone(self.exemplar)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<CloneFactory object at 0x{id(self):x} ({self.exemplar})>'
 
 
 class UUIDHandler(BaseHandler):
     """Serialize uuid.UUID objects"""
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: uuid.UUIDs, data: Dict[str, Any]) -> HandlerReturn:
         data['hex'] = obj.hex
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> uuid.UUID:
         return uuid.UUID(data['hex'])
 
 
@@ -262,11 +272,11 @@ UUIDHandler.handles(uuid.UUID)
 class LockHandler(BaseHandler):
     """Serialize threading.Lock objects"""
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: threading.Lock, data: Dict[str, Any]) -> HandlerReturn:
         data['locked'] = obj.locked()
         return data
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]) -> threading.Lock:
         lock = threading.Lock()
         if data.get('locked', False):
             lock.acquire()
@@ -280,10 +290,10 @@ LockHandler.handles(_lock.__class__)
 class TextIOHandler(BaseHandler):
     """Serialize file descriptors as None because we cannot roundtrip"""
 
-    def flatten(self, obj, data):
+    def flatten(self, obj: io.TextIOBase, data: Dict[str, Any]) -> None:
         return None
 
-    def restore(self, data):
+    def restore(self, data: Dict[str, Any]):
         """Restore should never get called because flatten() returns None"""
         raise AssertionError('Restoring IO.TextIOHandler is not supported')
 

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -16,7 +16,7 @@ import queue
 import re
 import threading
 import uuid
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
 
 from . import util
 
@@ -258,7 +258,7 @@ class CloneFactory:
 class UUIDHandler(BaseHandler):
     """Serialize uuid.UUID objects"""
 
-    def flatten(self, obj: uuid.UUIDs, data: Dict[str, Any]) -> HandlerReturn:
+    def flatten(self, obj: uuid.UUID, data: Dict[str, Any]) -> HandlerReturn:
         data['hex'] = obj.hex
         return data
 

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -23,7 +23,8 @@ from . import util
 T = TypeVar("T")
 # we can't import the below types directly from pickler/unpickler because we'd get a circular import
 ContextType = Union[  # type: ignore[valid-type]
-    TypeVar("Pickler", bound="Pickler"), TypeVar("Unpickler", bound="Unpickler")
+    TypeVar("Pickler", bound="Pickler"),
+    TypeVar("Unpickler", bound="Unpickler"),  # noqa: F821
 ]
 HandlerType = Type[Any]
 KeyType = Union[Type[Any], str]

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -21,6 +21,10 @@ from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
 from . import util
 
 T = TypeVar("T")
+BaseHandlerType = TypeVar("BaseHandler", bound="BaseHandler")
+ContextType = Union[
+    TypeVar("Pickler", bound="Pickler"), TypeVar("Unpickler", bound="Unpickler")
+]
 HandlerType = Type[Any]
 KeyType = Union[Type[Any], str]
 HandlerReturn = Union[Dict[str, Any], str]
@@ -141,7 +145,7 @@ class BaseHandler:
         return cls
 
     #
-    def __call__(self, context: Any) -> "BaseHandler":
+    def __call__(self, context: ContextType) -> BaseHandlerType:
         """This permits registering either Handler instances or classes
 
         :Parameters:

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -16,13 +16,10 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    Iterator,
     List,
     Optional,
     Sequence,
-    Tuple,
     Type,
-    TypeVar,
     Union,
 )
 

--- a/jsonpickle/tags.py
+++ b/jsonpickle/tags.py
@@ -7,31 +7,31 @@ these custom key names to identify dictionaries
 that need to be specially handled.
 """
 
-BYTES = 'py/bytes'
-B64 = 'py/b64'
-B85 = 'py/b85'
-FUNCTION = 'py/function'
-ID = 'py/id'
-INITARGS = 'py/initargs'
-ITERATOR = 'py/iterator'
-JSON_KEY = 'json://'
-MODULE = 'py/mod'
-NEWARGS = 'py/newargs'
-NEWARGSEX = 'py/newargsex'
-NEWOBJ = 'py/newobj'
-OBJECT = 'py/object'
-PROPERTY = 'py/property'
-REDUCE = 'py/reduce'
-REF = 'py/ref'
-REPR = 'py/repr'
-SEQ = 'py/seq'
-SET = 'py/set'
-STATE = 'py/state'
-TUPLE = 'py/tuple'
-TYPE = 'py/type'
+BYTES: str = 'py/bytes'
+B64: str = 'py/b64'
+B85: str = 'py/b85'
+FUNCTION: str = 'py/function'
+ID: str = 'py/id'
+INITARGS: str = 'py/initargs'
+ITERATOR: str = 'py/iterator'
+JSON_KEY: str = 'json://'
+MODULE: str = 'py/mod'
+NEWARGS: str = 'py/newargs'
+NEWARGSEX: str = 'py/newargsex'
+NEWOBJ: str = 'py/newobj'
+OBJECT: str = 'py/object'
+PROPERTY: str = 'py/property'
+REDUCE: str = 'py/reduce'
+REF: str = 'py/ref'
+REPR: str = 'py/repr'
+SEQ: str = 'py/seq'
+SET: str = 'py/set'
+STATE: str = 'py/state'
+TUPLE: str = 'py/tuple'
+TYPE: str = 'py/type'
 
 # All reserved tag names
-RESERVED = {
+RESERVED: set = {
     BYTES,
     FUNCTION,
     ID,

--- a/jsonpickle/tags_pd.py
+++ b/jsonpickle/tags_pd.py
@@ -3,7 +3,6 @@ This file exists to automatically generate tags for numpy/pandas extensions. Bec
 """
 
 import re
-from collections.abc import Iterable as _IterableABC
 from typing import Any, Dict, Iterable, List, Tuple, Type, Union
 
 import numpy as np

--- a/jsonpickle/tags_pd.py
+++ b/jsonpickle/tags_pd.py
@@ -148,8 +148,8 @@ def get_all_numpy_dtype_strings() -> List[str]:
         dt_variants = list(
             dict.fromkeys(
                 [
-                    "datetime64[" + re.search(r"\[(.*?)\]", var).group(1) + "]"
-                    for var in char_codes._DT64Codes.__args__
+                    "datetime64[" + re.search(r"\[(.*?)\]", var).group(1) + "]"  # type: ignore[union-attr]
+                    for var in char_codes._DT64Codes.__args__  # type: ignore[attr-defined]
                     if re.search(r"\[(.*?)\]", var)
                 ]
             )
@@ -157,8 +157,8 @@ def get_all_numpy_dtype_strings() -> List[str]:
         td_variants = list(
             dict.fromkeys(
                 [
-                    "timedelta64[" + re.search(r"\[(.*?)\]", var).group(1) + "]"
-                    for var in char_codes._TD64Codes.__args__
+                    "timedelta64[" + re.search(r"\[(.*?)\]", var).group(1) + "]"  # type: ignore[union-attr]
+                    for var in char_codes._TD64Codes.__args__  # type: ignore[attr-defined]
                     if re.search(r"\[(.*?)\]", var)
                 ]
             )

--- a/jsonpickle/tags_pd.py
+++ b/jsonpickle/tags_pd.py
@@ -3,13 +3,18 @@ This file exists to automatically generate tags for numpy/pandas extensions. Bec
 """
 
 import re
+from collections.abc import Iterable as _IterableABC
+from typing import Any, Dict, Iterable, List, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
 from pandas.api.extensions import ExtensionDtype
 
+DTypeRepr = Union[str, Type]
 
-def split_letters_numbers_brackets(s):
+
+# TODO: add tests for this module
+def split_letters_numbers_brackets(s: str) -> Tuple[str, str, str]:
     """
     Split the string into letters, numbers, and brackets (with their content).
     This is a helper function for getting the smallest unique substring, for determining tags.
@@ -32,7 +37,9 @@ def split_letters_numbers_brackets(s):
     return letters_part, numbers_part, brackets_part
 
 
-def get_smallest_unique_substrings(strings, prefix="np"):
+def get_smallest_unique_substrings(
+    strings: Iterable[Any], prefix: str = "np"
+) -> Dict[Any, str]:
     used_substrings = set()
     used_letters_parts = set()
     result = {}
@@ -115,7 +122,7 @@ def get_smallest_unique_substrings(strings, prefix="np"):
     return result
 
 
-def all_subclasses(cls):
+def all_subclasses(cls: Type[Any]) -> List[Type[Any]]:
     # use a set to avoid adding duplicates
     subclasses = set()
     for subclass in cls.__subclasses__():
@@ -124,7 +131,7 @@ def all_subclasses(cls):
     return list(subclasses)
 
 
-def get_all_numpy_dtype_strings():
+def get_all_numpy_dtype_strings() -> List[str]:
     dtypes = []
 
     # sctypeDict is the dict of all possible numpy dtypes + some invalid dtypes too
@@ -195,7 +202,7 @@ def get_all_numpy_dtype_strings():
     return list(dict.fromkeys(dtypes))
 
 
-def get_all_pandas_dtype_strings():
+def get_all_pandas_dtype_strings() -> List[DTypeRepr]:
     dtypes = []
 
     # get all pandas dtypes since it doesnt have a built-in api
@@ -216,20 +223,20 @@ def get_all_pandas_dtype_strings():
     return list(dict.fromkeys(dtypes))
 
 
-np_dtypes = list(
+np_dtypes: List[str] = list(
     dict.fromkeys(
         [dtype for dtype in get_all_numpy_dtype_strings() if isinstance(dtype, str)]
     )
 )
 
-pd_dtypes = list(
+pd_dtypes: List[str] = list(
     dict.fromkeys(
         [dtype for dtype in get_all_pandas_dtype_strings() if isinstance(dtype, str)]
     )
 )
 
 
-TYPE_MAP = get_smallest_unique_substrings(np_dtypes, prefix="np")
+TYPE_MAP: Dict[Any, str] = get_smallest_unique_substrings(np_dtypes, prefix="np")
 TYPE_MAP.update(get_smallest_unique_substrings(pd_dtypes, prefix="pd"))
 
-REVERSE_TYPE_MAP = {v: k for k, v in TYPE_MAP.items()}
+REVERSE_TYPE_MAP: Dict[str, Any] = {v: k for k, v in TYPE_MAP.items()}

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -105,7 +105,7 @@ def decode(
 
     if isinstance(on_missing, str):
         on_missing = on_missing.lower()
-    elif not util.is_function(on_missing):
+    elif not util._is_function(on_missing):
         warnings.warn(
             "Unpickler.on_missing must be a string or a function! It will be ignored!"
         )
@@ -668,7 +668,7 @@ class Unpickler:
             raise errors.ClassNotFoundError(
                 'Unpickler.restore_object could not find %s!' % class_name  # type: ignore[arg-type]
             )
-        elif util.is_function(self.on_missing):
+        elif util._is_function(self.on_missing):
             self.on_missing(class_name)  # type: ignore[operator]
 
     def _restore_pickled_key(self, key: str) -> Any:
@@ -729,7 +729,7 @@ class Unpickler:
                 value = self._restore(v)
             else:
                 value = v
-            if util.is_noncomplex(instance) or util.is_dictionary_subclass(instance):
+            if util._is_noncomplex(instance) or util._is_dictionary_subclass(instance):
                 try:
                     if k == '__dict__':
                         setattr(instance, k, value)

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -7,12 +7,11 @@
 import dataclasses
 import sys
 import warnings
-from types import FunctionType, ModuleType
+from types import ModuleType
 from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
     Iterator,
     List,
     Optional,
@@ -20,7 +19,6 @@ from typing import (
     Set,
     Tuple,
     Type,
-    TypeVar,
     Union,
 )
 

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -19,6 +19,7 @@ import time
 import types
 from collections.abc import Iterator as abc_iterator
 from typing import (
+    Any,
     Callable,
     Iterable,
     Iterator,
@@ -70,7 +71,7 @@ NON_CLASS_TYPES: set = {
 } | PRIMITIVES
 
 
-def is_type(obj: object) -> bool:
+def is_type(obj: Any) -> bool:
     """Returns True is obj is a reference to a type.
 
     >>> is_type(1)
@@ -87,7 +88,7 @@ def is_type(obj: object) -> bool:
     return isinstance(obj, type)
 
 
-def has_method(obj: object, name: str) -> bool:
+def has_method(obj: Any, name: str) -> bool:
     # false if attribute doesn't exist
     if not hasattr(obj, name):
         return False
@@ -134,7 +135,7 @@ def has_method(obj: object, name: str) -> bool:
     return isinstance(obj, type(bound_to))
 
 
-def is_object(obj: object) -> bool:
+def is_object(obj: Any) -> bool:
     """Returns True is obj is a reference to an object instance.
 
     >>> is_object(1)
@@ -151,14 +152,14 @@ def is_object(obj: object) -> bool:
     )
 
 
-def is_not_class(obj: object) -> bool:
+def is_not_class(obj: Any) -> bool:
     """Determines if the object is not a class or a class instance.
     Used for serializing properties.
     """
     return type(obj) in NON_CLASS_TYPES
 
 
-def is_primitive(obj: object) -> bool:
+def is_primitive(obj: Any) -> bool:
     """Helper method to see if the object is a basic data type. Unicode strings,
     integers, longs, floats, booleans, and None are considered primitive
     and will return True when passed into *is_primitive()*
@@ -171,12 +172,12 @@ def is_primitive(obj: object) -> bool:
     return type(obj) in PRIMITIVES
 
 
-def is_enum(obj: object) -> bool:
+def is_enum(obj: Any) -> bool:
     """Is the object an enum?"""
     return 'enum' in sys.modules and isinstance(obj, sys.modules['enum'].Enum)
 
 
-def is_sequence(obj: object) -> bool:
+def is_sequence(obj: Any) -> bool:
     """Helper method to see if the object is a sequence (list, set, or tuple).
 
     >>> is_sequence([4])
@@ -186,7 +187,7 @@ def is_sequence(obj: object) -> bool:
     return type(obj) in SEQUENCES_SET
 
 
-def is_dictionary_subclass(obj: object) -> bool:
+def is_dictionary_subclass(obj: Any) -> bool:
     """Returns True if *obj* is a subclass of the dict type. *obj* must be
     a subclass and not the actual builtin dict.
 
@@ -202,7 +203,7 @@ def is_dictionary_subclass(obj: object) -> bool:
     )
 
 
-def is_sequence_subclass(obj: object) -> bool:
+def is_sequence_subclass(obj: Any) -> bool:
     """Returns True if *obj* is a subclass of list, set or tuple.
 
     *obj* must be a subclass and not the actual builtin, such
@@ -219,7 +220,7 @@ def is_sequence_subclass(obj: object) -> bool:
     )
 
 
-def is_noncomplex(obj: object) -> bool:
+def is_noncomplex(obj: Any) -> bool:
     """Returns True if *obj* is a special (weird) class, that is more complex
     than primitive data types, but is not a full object. Including:
 
@@ -230,7 +231,7 @@ def is_noncomplex(obj: object) -> bool:
     return False
 
 
-def is_function(obj: object) -> bool:
+def is_function(obj: Any) -> bool:
     """Returns true if passed a function
 
     >>> is_function(lambda x: 1)
@@ -249,7 +250,7 @@ def is_function(obj: object) -> bool:
     return type(obj) in FUNCTION_TYPES
 
 
-def is_module_function(obj: object) -> bool:
+def is_module_function(obj: Any) -> bool:
     """Return True if `obj` is a module-global function
 
     >>> import os
@@ -290,7 +291,7 @@ def is_picklable(name: str, value: types.FunctionType) -> bool:
     return is_module_function(value) or not is_function(value)
 
 
-def is_installed(module: types.ModuleType) -> bool:
+def is_installed(module: str) -> bool:
     """Tests to see if ``module`` is available on the sys.path
 
     >>> is_installed('sys')
@@ -306,26 +307,26 @@ def is_installed(module: types.ModuleType) -> bool:
         return False
 
 
-def is_list_like(obj: object) -> bool:
+def is_list_like(obj: Any) -> bool:
     return hasattr(obj, '__getitem__') and hasattr(obj, 'append')
 
 
-def is_iterator(obj: object) -> bool:
+def is_iterator(obj: Any) -> bool:
     return isinstance(obj, abc_iterator) and not isinstance(obj, io.IOBase)
 
 
-def is_collections(obj: object) -> bool:
+def is_collections(obj: Any) -> bool:
     try:
         return type(obj).__module__ == 'collections'
     except Exception:
         return False
 
 
-def is_reducible_sequence_subclass(obj: object) -> bool:
+def is_reducible_sequence_subclass(obj: Any) -> bool:
     return hasattr(obj, '__class__') and issubclass(obj.__class__, SEQUENCES)
 
 
-def is_reducible(obj: object) -> bool:
+def is_reducible(obj: Any) -> bool:
     """
     Returns false if of a type which have special casing,
     and should not have their __reduce__ methods used
@@ -347,7 +348,7 @@ def is_reducible(obj: object) -> bool:
     return True
 
 
-def is_cython_function(obj: object) -> bool:
+def is_cython_function(obj: Any) -> bool:
     """Returns true if the object is a reference to a Cython function"""
     return (
         callable(obj)
@@ -356,7 +357,7 @@ def is_cython_function(obj: object) -> bool:
     )
 
 
-def is_readonly(obj: object, attr: str, value: object) -> bool:
+def is_readonly(obj: Any, attr: str, value: Any) -> bool:
     # CPython 3.11+ has 0-cost try/except, please use up-to-date versions!
     try:
         setattr(obj, attr, value)
@@ -370,7 +371,7 @@ def is_readonly(obj: object, attr: str, value: object) -> bool:
         return True
 
 
-def in_dict(obj: object, key: str, default: bool = False) -> bool:
+def in_dict(obj: Any, key: str, default: bool = False) -> bool:
     """
     Returns true if key exists in obj.__dict__; false if not in.
     If obj.__dict__ is absent, return default
@@ -378,7 +379,7 @@ def in_dict(obj: object, key: str, default: bool = False) -> bool:
     return (key in obj.__dict__) if getattr(obj, '__dict__', None) else default
 
 
-def in_slots(obj: object, key: str, default: bool = False) -> bool:
+def in_slots(obj: Any, key: str, default: bool = False) -> bool:
     """
     Returns true if key exists in obj.__slots__; false if not in.
     If obj.__slots__ is absent, return default
@@ -386,7 +387,7 @@ def in_slots(obj: object, key: str, default: bool = False) -> bool:
     return (key in obj.__slots__) if getattr(obj, '__slots__', None) else default
 
 
-def has_reduce(obj: object) -> Tuple[bool, bool]:
+def has_reduce(obj: Any) -> Tuple[bool, bool]:
     """
     Tests if __reduce__ or __reduce_ex__ exists in the object dict or
     in the class dicts of every class in the MRO *except object*.

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -21,6 +21,7 @@ import warnings
 from collections.abc import Iterator as abc_iterator
 
 from . import tags
+from typing import Any, Dict, Optional, Tuple, Union
 
 _ITERATOR_TYPE = type(iter(''))
 SEQUENCES = (list, set, tuple)
@@ -54,7 +55,7 @@ NON_CLASS_TYPES = {
 } | PRIMITIVES
 
 
-def is_type(obj):
+def is_type(obj: Any) -> bool:
     """Returns True is obj is a reference to a type.
 
     >>> is_type(1)
@@ -71,7 +72,7 @@ def is_type(obj):
     return isinstance(obj, type)
 
 
-def has_method(obj, name):
+def has_method(obj: Any, name: str) -> bool:
     # false if attribute doesn't exist
     if not hasattr(obj, name):
         return False
@@ -118,7 +119,8 @@ def has_method(obj, name):
     return isinstance(obj, type(bound_to))
 
 
-def is_object(obj):
+# used in one place, TODO remove by 5.0.0
+def is_object(obj: Any) -> bool:
     """Returns True is obj is a reference to an object instance.
 
     >>> is_object(1)
@@ -135,14 +137,15 @@ def is_object(obj):
     )
 
 
-def is_not_class(obj):
+# used in one place, TODO remove by 5.0.0
+def is_not_class(obj: Any) -> bool:
     """Determines if the object is not a class or a class instance.
     Used for serializing properties.
     """
     return type(obj) in NON_CLASS_TYPES
 
 
-def is_primitive(obj):
+def is_primitive(obj: Any) -> bool:
     """Helper method to see if the object is a basic data type. Unicode strings,
     integers, longs, floats, booleans, and None are considered primitive
     and will return True when passed into *is_primitive()*
@@ -155,12 +158,13 @@ def is_primitive(obj):
     return type(obj) in PRIMITIVES
 
 
-def is_enum(obj):
+def is_enum(obj: Any) -> bool:
     """Is the object an enum?"""
     return 'enum' in sys.modules and isinstance(obj, sys.modules['enum'].Enum)
 
 
-def is_dictionary(obj):
+# used only in tests and jsonpickleJS, TODO remove by 5.0.0
+def is_dictionary(obj: Any) -> bool:
     """Helper method for testing if the object is a dictionary.
 
     >>> is_dictionary({'key':'value'})
@@ -173,8 +177,8 @@ def is_dictionary(obj):
     )
     return type(obj) is dict
 
-
-def is_sequence(obj):
+# used only in tests, TODO remove by 5.0.0
+def is_sequence(obj: Any) -> bool:
     """Helper method to see if the object is a sequence (list, set, or tuple).
 
     >>> is_sequence([4])
@@ -184,7 +188,7 @@ def is_sequence(obj):
     return type(obj) in SEQUENCES_SET
 
 
-def is_list(obj):
+def is_list(obj: Any) -> bool:
     """Helper method to see if the object is a Python list.
 
     >>> is_list([4])
@@ -196,8 +200,8 @@ def is_list(obj):
     )
     return type(obj) is list
 
-
-def is_set(obj):
+# used only in tests and jsonpickleJS, TODO remove by 5.0.0
+def is_set(obj: Any) -> bool:
     """Helper method to see if the object is a Python set.
 
     >>> is_set(set())
@@ -209,8 +213,8 @@ def is_set(obj):
     )
     return type(obj) is set
 
-
-def is_bytes(obj):
+# not used anywhere, TODO remove by 5.0.0
+def is_bytes(obj: Any) -> bool:
     """Helper method to see if the object is a bytestring.
 
     >>> is_bytes(b'foo')
@@ -222,8 +226,8 @@ def is_bytes(obj):
     )
     return type(obj) is bytes
 
-
-def is_unicode(obj):
+# not used anywhere, TODO remove by 5.0.0
+def is_unicode(obj: Any) -> bool:
     """DEPRECATED: Helper method to see if the object is a unicode string"""
     warnings.warn(
         "This function will be removed in the next release of jsonpickle, 5.0.0! Please migrate now.",
@@ -231,8 +235,8 @@ def is_unicode(obj):
     )
     return type(obj) is str
 
-
-def is_tuple(obj):
+# used only in tests and jsonpickleJS, TODO remove by 5.0.0
+def is_tuple(obj: Any) -> bool:
     """Helper method to see if the object is a Python tuple.
 
     >>> is_tuple((1,))
@@ -245,7 +249,7 @@ def is_tuple(obj):
     return type(obj) is tuple
 
 
-def is_dictionary_subclass(obj):
+def is_dictionary_subclass(obj: Any) -> bool:
     """Returns True if *obj* is a subclass of the dict type. *obj* must be
     a subclass and not the actual builtin dict.
 
@@ -261,7 +265,7 @@ def is_dictionary_subclass(obj):
     )
 
 
-def is_sequence_subclass(obj):
+def is_sequence_subclass(obj: Any) -> bool:
     """Returns True if *obj* is a subclass of list, set or tuple.
 
     *obj* must be a subclass and not the actual builtin, such
@@ -278,7 +282,7 @@ def is_sequence_subclass(obj):
     )
 
 
-def is_noncomplex(obj):
+def is_noncomplex(obj: Any) -> bool:
     """Returns True if *obj* is a special (weird) class, that is more complex
     than primitive data types, but is not a full object. Including:
 
@@ -289,7 +293,7 @@ def is_noncomplex(obj):
     return False
 
 
-def is_function(obj):
+def is_function(obj: Any) -> bool:
     """Returns true if passed a function
 
     >>> is_function(lambda x: 1)
@@ -308,7 +312,7 @@ def is_function(obj):
     return type(obj) in FUNCTION_TYPES
 
 
-def is_module_function(obj):
+def is_module_function(obj: Any) -> bool:
     """Return True if `obj` is a module-global function
 
     >>> import os
@@ -329,7 +333,7 @@ def is_module_function(obj):
     ) or is_cython_function(obj)
 
 
-def is_module(obj):
+def is_module(obj: Any) -> bool:
     """Returns True if passed a module
 
     >>> import os
@@ -344,7 +348,7 @@ def is_module(obj):
     return isinstance(obj, types.ModuleType)
 
 
-def is_picklable(name, value):
+def is_picklable(name: str, value: types.FunctionType) -> bool:
     """Return True if an object can be pickled
 
     >>> import os
@@ -364,7 +368,7 @@ def is_picklable(name, value):
     return is_module_function(value) or not is_function(value)
 
 
-def is_installed(module):
+def is_installed(module: types.ModuleType):
     """Tests to see if ``module`` is available on the sys.path
 
     >>> is_installed('sys')
@@ -380,26 +384,26 @@ def is_installed(module):
         return False
 
 
-def is_list_like(obj):
+def is_list_like(obj: Any) -> bool:
     return hasattr(obj, '__getitem__') and hasattr(obj, 'append')
 
 
-def is_iterator(obj):
+def is_iterator(obj: Any) -> bool:
     return isinstance(obj, abc_iterator) and not isinstance(obj, io.IOBase)
 
 
-def is_collections(obj):
+def is_collections(obj: Any) -> bool:
     try:
         return type(obj).__module__ == 'collections'
     except Exception:
         return False
 
 
-def is_reducible_sequence_subclass(obj):
+def is_reducible_sequence_subclass(obj: Any) -> bool:
     return hasattr(obj, '__class__') and issubclass(obj.__class__, SEQUENCES)
 
 
-def is_reducible(obj):
+def is_reducible(obj: Any) -> bool:
     """
     Returns false if of a type which have special casing,
     and should not have their __reduce__ methods used
@@ -421,7 +425,7 @@ def is_reducible(obj):
     return True
 
 
-def is_cython_function(obj):
+def is_cython_function(obj: Any) -> bool:
     """Returns true if the object is a reference to a Cython function"""
     return (
         callable(obj)
@@ -430,7 +434,7 @@ def is_cython_function(obj):
     )
 
 
-def is_readonly(obj, attr, value):
+def is_readonly(obj: Any, attr: str, value: Any) -> bool:
     # CPython 3.11+ has 0-cost try/except, please use up-to-date versions!
     try:
         setattr(obj, attr, value)
@@ -444,7 +448,7 @@ def is_readonly(obj, attr, value):
         return True
 
 
-def in_dict(obj, key, default=False):
+def in_dict(obj: Any, key: str, default: bool=False) -> bool:
     """
     Returns true if key exists in obj.__dict__; false if not in.
     If obj.__dict__ is absent, return default
@@ -452,7 +456,7 @@ def in_dict(obj, key, default=False):
     return (key in obj.__dict__) if getattr(obj, '__dict__', None) else default
 
 
-def in_slots(obj, key, default=False):
+def in_slots(obj: Any, key: str, default: bool=False) -> bool:
     """
     Returns true if key exists in obj.__slots__; false if not in.
     If obj.__slots__ is absent, return default
@@ -460,7 +464,7 @@ def in_slots(obj, key, default=False):
     return (key in obj.__slots__) if getattr(obj, '__slots__', None) else default
 
 
-def has_reduce(obj):
+def has_reduce(obj: Any) -> Tuple[bool, bool]:
     """
     Tests if __reduce__ or __reduce_ex__ exists in the object dict or
     in the class dicts of every class in the MRO *except object*.
@@ -513,7 +517,8 @@ def has_reduce(obj):
     return (has_reduce, has_reduce_ex)
 
 
-def translate_module_name(module):
+# this function isn't used anywhere, it should be deleted by 5.0.0 so types shouldn't matter
+def translate_module_name(module: Any) -> Any:
     """Rename builtin modules to a consistent module name.
 
     Prefer the more modern naming.
@@ -532,7 +537,7 @@ def translate_module_name(module):
     return lookup.get(module, module)
 
 
-def _0_9_6_compat_untranslate(module):
+def _0_9_6_compat_untranslate(module: str) -> str:
     """Provide compatibility for pickles created with jsonpickle 0.9.6 and
     earlier, remapping `exceptions` and `__builtin__` to `builtins`.
     """
@@ -540,7 +545,7 @@ def _0_9_6_compat_untranslate(module):
     return lookup.get(module, module)
 
 
-def untranslate_module_name(module):
+def untranslate_module_name(module: str) -> str:
     """Rename module names mention in JSON to names that we can import
 
     This reverses the translation applied by translate_module_name() to
@@ -550,7 +555,7 @@ def untranslate_module_name(module):
     return _0_9_6_compat_untranslate(module)
 
 
-def importable_name(cls):
+def importable_name(cls: Any) -> str:
     """
     >>> class Example(object):
     ...     pass
@@ -580,14 +585,14 @@ def importable_name(cls):
     return f'{module}.{name}'
 
 
-def b64encode(data):
+def b64encode(data: bytes) -> str:
     """
     Encode binary data to ascii text in base64. Data must be bytes.
     """
     return base64.b64encode(data).decode('ascii')
 
 
-def b64decode(payload):
+def b64decode(payload: str) -> bytes:
     """
     Decode payload - must be ascii text.
     """
@@ -597,14 +602,14 @@ def b64decode(payload):
         return b''
 
 
-def b85encode(data):
+def b85encode(data: bytes) -> str:
     """
     Encode binary data to ascii text in base85. Data must be bytes.
     """
     return base64.b85encode(data).decode('ascii')
 
 
-def b85decode(payload):
+def b85decode(payload: bytes) -> bytes:
     """
     Decode payload - must be ascii text.
     """
@@ -614,11 +619,11 @@ def b85decode(payload):
         return b''
 
 
-def itemgetter(obj, getter=operator.itemgetter(0)):
+def itemgetter(obj: Any, getter: Any=operator.itemgetter(0)) -> str:
     return str(getter(obj))
 
 
-def items(obj, exclude=()):
+def items(obj: Any, exclude=()):
     """
     This can't be easily replaced by dict.items() because this has the exclude parameter.
     Keep it for now.

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -25,7 +25,9 @@ from typing import (
     Iterator,
     Mapping,
     Tuple,
+    Type,
     TypeVar,
+    Union,
 )
 
 from . import tags
@@ -36,8 +38,6 @@ K = TypeVar("K")
 V = TypeVar("V")
 # type
 T = TypeVar("T")
-# return value
-R = TypeVar("R")
 
 _ITERATOR_TYPE: type = type(iter(''))
 SEQUENCES: tuple = (list, set, tuple)
@@ -477,7 +477,7 @@ def untranslate_module_name(module: str) -> str:
     return _0_9_6_compat_untranslate(module)
 
 
-def importable_name(cls: type) -> str:
+def importable_name(cls: Union[Type, Callable[..., Any]]) -> str:
     """
     >>> class Example(object):
     ...     pass
@@ -541,7 +541,7 @@ def b85decode(payload: bytes) -> bytes:
         return b''
 
 
-def itemgetter(obj: T, getter: Callable[[T], R] = operator.itemgetter(0)) -> str:
+def itemgetter(obj: T, getter: Callable[[T], Any] = operator.itemgetter(0)) -> str:  # type: ignore[assignment]
     return str(getter(obj))
 
 

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -38,18 +38,18 @@ T = TypeVar("T")
 # return value
 R = TypeVar("R")
 
-_ITERATOR_TYPE = type(iter(''))
-SEQUENCES = (list, set, tuple)
-SEQUENCES_SET = {list, set, tuple}
-PRIMITIVES = {str, bool, int, float, type(None)}
-FUNCTION_TYPES = {
+_ITERATOR_TYPE: type = type(iter(''))
+SEQUENCES: tuple = (list, set, tuple)
+SEQUENCES_SET: set = {list, set, tuple}
+PRIMITIVES: set = {str, bool, int, float, type(None)}
+FUNCTION_TYPES: set = {
     types.FunctionType,
     types.MethodType,
     types.LambdaType,
     types.BuiltinFunctionType,
     types.BuiltinMethodType,
 }
-NON_REDUCIBLE_TYPES = (
+NON_REDUCIBLE_TYPES: set = (
     {
         list,
         dict,
@@ -61,7 +61,7 @@ NON_REDUCIBLE_TYPES = (
     | PRIMITIVES
     | FUNCTION_TYPES
 )
-NON_CLASS_TYPES = {
+NON_CLASS_TYPES: set = {
     list,
     dict,
     set,

--- a/jsonpickle/version.py
+++ b/jsonpickle/version.py
@@ -1,10 +1,10 @@
 try:
     from importlib import metadata
 except (ImportError, OSError):
-    metadata = None
+    metadata = None  # type: ignore
 
 
-def _get_version():
+def _get_version() -> str:
     default_version = '0.0.0-alpha'
     try:
         version = metadata.version('jsonpickle')

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+disable_error_code = var-annotated, return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ testing = [
     "ujson",
     # fuzzing
     "atheris ~= 2.3.0; python_version < '3.12'",
+    # type checking
+    "mypy",
+    "pandas-stubs",
 ]
 docs = [
     "furo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,4 +96,5 @@ addopts = "--ruff"
 
 [tool.ruff.lint]
 # E721 Do not compare types -> jsonpickle compares types using "is" for performance.
-ignore = ["E721"]
+# E402 Module level import not at top of file -> this is expected behavior for isort and black
+ignore = ["E721", "E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Python :: 3.9",
+    "Python :: 3.10",
+    "Python :: 3.11",
+    "Python :: 3.12",
+    "Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
 ]
 dynamic = ["version"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-norecursedirs=dist build .eggs .tox
+norecursedirs=dist build .eggs .tox fuzzing
 addopts=--doctest-modules
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 filterwarnings=

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -34,7 +34,7 @@ SAMPLE_DATA = {'things': [Thing('data')]}
 
 class BackendBase(SkippableTest):
     def _is_installed(self, backend):
-        if not jsonpickle.util.is_installed(backend):
+        if not jsonpickle.util._is_installed(backend):
             return self.skip('%s not available; please install' % backend)
 
     def set_backend(self, *args):

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1669,7 +1669,7 @@ def test_reduce_newobj():
 def test_reduce_iter():
     """Iterators with ``__reduce__`` can roundtrip"""
     instance = iter('123')
-    assert util.is_iterator(instance)
+    assert util._is_iterator(instance)
     encoded = jsonpickle.encode(instance)
     decoded = jsonpickle.decode(encoded)
     assert next(decoded) == '1'
@@ -1680,7 +1680,7 @@ def test_reduce_iter():
 def test_reduce_iterable():
     """Reducible objects that are iterable should also pickle"""
     instance = ReducibleIterator()
-    assert util.is_iterator(instance)
+    assert util._is_iterator(instance)
     encoded = jsonpickle.encode(instance)
     decoded = jsonpickle.decode(encoded)
     assert isinstance(decoded, ReducibleIterator)

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -820,7 +820,7 @@ def test_ordered_dict_reduces():
     """Ensure that OrderedDict is reduce()-able"""
     d = collections.OrderedDict([('c', 3), ('a', 1), ('b', 2)])
     has_reduce, has_reduce_ex = util.has_reduce(d)
-    assert util.is_reducible(d)
+    assert util._is_reducible(d)
     assert has_reduce or has_reduce_ex
 
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -50,102 +50,96 @@ class MethodTestOldStyle:
 
 
 def test_is_primitive_int():
-    assert util.is_primitive(0)
-    assert util.is_primitive(3)
-    assert util.is_primitive(-3)
+    assert util._is_primitive(0)
+    assert util._is_primitive(3)
+    assert util._is_primitive(-3)
 
 
 def test_is_primitive_float():
-    assert util.is_primitive(0)
-    assert util.is_primitive(3.5)
-    assert util.is_primitive(-3.5)
-    assert util.is_primitive(float(3))
+    assert util._is_primitive(0)
+    assert util._is_primitive(3.5)
+    assert util._is_primitive(-3.5)
+    assert util._is_primitive(float(3))
 
 
 def test_is_primitive_long():
-    assert util.is_primitive(2**64)
+    assert util._is_primitive(2**64)
 
 
 def test_is_primitive_bool():
-    assert util.is_primitive(True)
-    assert util.is_primitive(False)
+    assert util._is_primitive(True)
+    assert util._is_primitive(False)
 
 
 def test_is_primitive_None():
-    assert util.is_primitive(None)
+    assert util._is_primitive(None)
 
 
 def test_is_primitive_bytes():
-    assert not util.is_primitive(b'hello')
-    assert not util.is_primitive(b'foo')
-    assert util.is_primitive('foo')
+    assert not util._is_primitive(b'hello')
+    assert not util._is_primitive(b'foo')
+    assert util._is_primitive('foo')
 
 
 def test_is_primitive_unicode():
-    assert util.is_primitive('')
-    assert util.is_primitive('hello')
+    assert util._is_primitive('')
+    assert util._is_primitive('hello')
 
 
 def test_is_primitive_list():
-    assert not util.is_primitive([])
-    assert not util.is_primitive([4, 4])
+    assert not util._is_primitive([])
+    assert not util._is_primitive([4, 4])
 
 
 def test_is_primitive_dict():
-    assert not util.is_primitive({'key': 'value'})
-    assert not util.is_primitive({})
+    assert not util._is_primitive({'key': 'value'})
+    assert not util._is_primitive({})
 
 
 def test_is_primitive_tuple():
-    assert not util.is_primitive((1, 3))
-    assert not util.is_primitive((1,))
+    assert not util._is_primitive((1, 3))
+    assert not util._is_primitive((1,))
 
 
 def test_is_primitive_set():
-    assert not util.is_primitive({1, 3})
+    assert not util._is_primitive({1, 3})
 
 
 def test_is_primitive_object():
-    assert not util.is_primitive(Thing('test'))
-
-
-def test_is_sequence_various():
-    assert util.is_sequence([])
-    assert util.is_sequence(tuple())
-    assert util.is_sequence(set())
+    assert not util._is_primitive(Thing('test'))
 
 
 def test_is_dictionary_subclass_dict():
-    assert not util.is_dictionary_subclass({})
+    assert not util._is_dictionary_subclass({})
 
 
 def test_is_dictionary_subclass_subclass():
-    assert util.is_dictionary_subclass(DictSubclass())
+    assert util._is_dictionary_subclass(DictSubclass())
 
 
 def test_is_sequence_subclass_subclass():
-    assert util.is_sequence_subclass(ListSubclass())
+    assert util._is_sequence_subclass(ListSubclass())
 
 
 def test_is_sequence_subclass_list():
-    assert not util.is_sequence_subclass([])
+    assert not util._is_sequence_subclass([])
 
 
 def test_is_noncomplex_time_struct():
     t = time.struct_time('123456789')
-    assert util.is_noncomplex(t)
+    assert util._is_noncomplex(t)
 
 
 def test_is_noncomplex_other():
-    assert not util.is_noncomplex('a')
+    assert not util._is_noncomplex('a')
 
 
 def test_is_function_builtins():
-    assert util.is_function(globals)
+    assert util._is_function(globals)
 
 
 def test_is_function_lambda():
-    assert util.is_function(lambda: False)
+    assert util._is_function(lambda: False)
 
 
 def test_is_function_instance_method():
@@ -162,9 +156,9 @@ def test_is_function_instance_method():
             pass
 
     f = Foo()
-    assert util.is_function(f.method)
-    assert util.is_function(f.staticmethod)
-    assert util.is_function(f.classmethod)
+    assert util._is_function(f.method)
+    assert util._is_function(f.staticmethod)
+    assert util._is_function(f.classmethod)
 
 
 def test_itemgetter():


### PR DESCRIPTION
This is sort of an omnibus PR ("big beautiful bill" --> "prodigious proposed PR"), with adding type hints to the public API, dropping support for python 3.7 and 3.8 and adding it for 3.13, moving some util functions to the private API so we can change them without worrying about backwards compatibility, and removing some deprecated functions. That's why there's a large amount of churn. I considered splitting each of the above updates into separate PRs but the function removal needed to be done before type hints, and dropping support for old python versions fit well with the new mypy addition to the testing matrix. **This is not everything that will be necessary for 5.0.0. so we can't tag v5 yet.**

You'll see that the commit times are almost all from 3 days ago, that's because I messed up some git merge/cherry-pick operation across branches and it reset the commit times. I've spent something like ~20 hours over the past week alone on this, so I'm going to have to take a break for a few days, then I'll move on to the rest of the 5.0.0 milestones.

Closes #441, #554, #561