### PR TITLE
Create attestation & releasing instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,12 @@ repos:
   - id: isort
     args:
       - --profile=black
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.16.1
+  hooks:
+  - id: mypy
+    types: [python]
+    args: [--strict]
+    pass_filenames: false
+    language: system

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ This document serves as a reminder for jsonpickle developers on how to tag, buil
 ## Git
 ```sh
 git tag -a vx.y.z
-git push origin main
+git push --tags origin main
 ```
 
 # GitHub

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,31 @@
+# Release Process
+
+## Purpose
+This document serves as a reminder for jsonpickle developers on how to tag, build, and publish jsonpickle releases for Git, GitHub and PyPi. All commands included are meant for a Linux system with the appropiate prerequisites met (such as Python being installed, Git being installed, etc.) The instructions here mostly parallel those in garden.yaml, but are meant for quicker and more intuitive reference for those without garden installed.
+
+## Prerequisites
+- Clear staging area of irrelevant files
+- Clear pre-existing files from build/ and dist/
+- Make sure everything important has been committed and pushed already
+- Run tests and **ensure everything passes**
+
+## Git
+```sh
+git tag -a vx.y.z
+git push origin main
+```
+
+# GitHub
+GitHub releases are created automatically by GitHub Actions when the git tag is pushed.
+
+# PyPi
+```sh
+# create wheels
+python3 -m build -n .
+
+# create attestations (use github account)
+python3 -m pypi_attestations sign dist/*
+
+# publish to PyPi
+twine upload --attestations dist/*.whl dist/*.tar.gz
+```

--- a/garden.yaml
+++ b/garden.yaml
@@ -52,7 +52,8 @@ trees:
         python3 -m build -n .
       publish: |
         ${activate}
-        twine upload dist/*.whl dist/*.tar.gz
+        python3 -m pypi_attestations sign dist/*
+        twine upload --attestations dist/*.whl dist/*.tar.gz
     remotes:
       aldanor: "git@github.com:aldanor/jsonpickle.git"
       cdce8p: "git@github.com:cdce8p/jsonpickle.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ packaging = [
     "setuptools>=61.2",
     "setuptools_scm[toml]>=6.0",
     "twine",
+    "pypi-attestations",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
The main change here is the introduction of attestations into the release workflow. This should hopefully increase public trust in the build process (not that it's particularly low to begin with) now that PGP/GPG signatures have been removed from PyPi. See [PyPi docs](https://docs.pypi.org/attestations/producing-attestations/) and [Trail of Bits](https://blog.trailofbits.com/2024/11/14/attestations-a-new-generation-of-signatures-on-pypi/) for more details on attestations. I decided to start with a CLI implementation of attestations to avoid adding a hard dependency on GitHub Actions (since all the existing workflows can already be done local-first). We can move the release process to GHA sometime in the future, I was just hoping to see whether Microsoft would keep pushing Copilot on GitHub users first (in my view, if they keep pushing it I'd be more inclined to make this all work on GitLab). Also, I added releasing documentation so I don't have to remember to reference garden.yaml every time (garden was a bit annoying to set up last time I tried around a year ago, and I never got to finish that process).

David, could you test the new garden file on a dummy release (take an existing release like 4.1.1 and run the build & publish workflow without the twine upload step) before I merge this?