### PR TITLE
fix: change restore parameter from obj to data

### DIFF
--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -124,7 +124,7 @@ class BaseHandler:
         """
         raise NotImplementedError('You must implement flatten() in %s' % self.__class__)
 
-    def restore(self, obj: Any) -> Any:
+    def restore(self, data: Dict[str, Any]) -> Any:
         """
         Restore an object of the registered type from the json-friendly
         representation `obj` and return it.


### PR DESCRIPTION
This change makes the signature of BaseHandler consistent with other handlers.