### PR TITLE
unpickler: avoid holding on to external references

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -111,6 +111,7 @@ def decode(
         )
 
     backend = backend or json
+    is_ephemeral_context = context is None
     context = context or Unpickler(
         keys=keys,
         backend=backend,
@@ -120,7 +121,12 @@ def decode(
         handle_readonly=handle_readonly,
     )
     data = backend.decode(string)
-    return context.restore(data, reset=reset, classes=classes)
+    result = context.restore(data, reset=reset, classes=classes)
+    if is_ephemeral_context:
+        # Avoid holding onto references to external objects, which can
+        # prevent garbage collection from occuring.
+        context.reset()
+    return result
 
 
 def _safe_hasattr(obj: Any, attr: str) -> bool:

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -404,3 +404,33 @@ def test_np_datetime64_units():
     obj = np.datetime64('2006', 'Y')
     encoded = jsonpickle.encode(obj)
     assert obj == jsonpickle.decode(encoded)
+
+
+class ThingWithDel:
+    def __init__(self, data):
+        self.data = data
+        self.fn = None
+
+    def __del__(self):
+        if self.fn is not None:
+            self.fn()
+
+
+def test_no_external_references():
+    """Ensure that no external references are held"""
+    state = {'count': 0}  # How many times has the destructor been called?
+
+    def destructor():
+        state['count'] += 1
+
+    obj = ThingWithDel(data=np.array([1, 2, 3]))
+
+    obj_encoded = jsonpickle.encode(obj)
+    obj.fn = destructor
+    del obj
+
+    obj2 = jsonpickle.decode(obj_encoded)
+    obj2.fn = destructor
+    del obj2
+
+    assert state['count'] == 2


### PR DESCRIPTION
Even though the unpickler goes out of scope immediately after decode() completes, the Python garbage collector is not able to determine that garbage collection can occur despite the fact that no references are being held. The observed behavior is that Python is not deleting the ephemeral unpickler instance.

Make this easier for the GC to handle by explicitly resetting the ephemeral Unpickler instance at the end of decode(). This guarantees that no external references are being held and allows them to be cleaned up in a slightly more predictable fashion.

Closes: #579