### PR TITLE
docs: fix encode() backend param docstring: serialization not deserialization

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -74,7 +74,7 @@ def encode(
         This flag is not typically used outside of a custom handler or
         `__getstate__` implementation.
     :param backend: If set to an instance of jsonpickle.backend.JSONBackend,
-        jsonpickle will use that backend for deserialization.
+        jsonpickle will use that backend for serialization.
     :param warn: If set to True then jsonpickle will warn when it
         returns None for an object which it cannot pickle
         (e.g. file descriptors).


### PR DESCRIPTION
The `backend` parameter docstring in `encode()` (pickler.py) says the backend is used for *deserialization*, but `encode()` calls `backend.encode(...)` -- it performs *serialization*. The decode counterpart in unpickler.py correctly says *deserialization*.

- [ ] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``black``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guideliens:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer containing the name of all generative AI models used.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.

---

Fix the `backend` parameter docstring in `encode()`: the function calls `backend.encode(...)` for serialization, so the description should say "serialization", not "deserialization". The `decode()` function's identical parameter in unpickler.py already correctly says "deserialization".

Assisted-by: Claude Sonnet 4.6