### PR TITLE
Add deprecation warnings to 4.1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
   - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.4.0
+  rev: v1.12.1
   hooks:
   - id: blacken-docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Upcoming
       You can re-enable yaml support using ``jsonpickle.ext.yaml.register()``.
       (#550) (+551)
 
+v4.1.2
+======
+    * Add deprecation warnings for the pending removal of the ``safe``, ``numeric_keys``, and
+      ``use_decimal`` arguments, as well as the pending change of ``keys`` parameter to default
+      to ``True``. (+600)
+
 v4.1.1
 ======
     * Maintenance release to omit upcoming breaking changes.

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -145,6 +145,26 @@ def encode(
     '{"foo": "[1, 2, [3, 4]]"}'
 
     """
+    # use stacklevel=2 to only warn on top-level user calls
+    if context is None:
+        if not keys:
+            warnings.warn(
+                "keys will default to True in jsonpickle 5.0.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if numeric_keys:
+            warnings.warn(
+                "numeric_keys is deprecated, use keys=True (will remove in 5.0.0)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if use_decimal:
+            warnings.warn(
+                "use_decimal is deprecated and will be removed in jsonpickle 5.0.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
     backend = backend or json
     context = context or Pickler(
         unpicklable=unpicklable,
@@ -840,9 +860,9 @@ class Pickler:
             if not self.unpicklable:
                 return self._list_recurse
             return lambda obj: {
-                tags.TUPLE if type(obj) is tuple else tags.SET: [
-                    self._flatten(v) for v in obj
-                ]
+                tags.TUPLE
+                if type(obj) is tuple
+                else tags.SET: [self._flatten(v) for v in obj]
             }
 
         elif util.is_module_function(obj):

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -83,6 +83,20 @@ def decode(
     36
     """
 
+    # use stacklevel=2 to only warn on top-level user calls
+    if context is None:
+        if not keys:
+            warnings.warn(
+                "keys will default to True in jsonpickle 5.0.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if not safe:
+            warnings.warn(
+                "safe=False is deprecated and will be removed in jsonpickle 5.0.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
     if isinstance(on_missing, str):
         on_missing = on_missing.lower()
     elif not util.is_function(on_missing):


### PR DESCRIPTION
Thank you for contributing to jsonpickle! This is just a quick template for you to fill out to make sure that jsonpickle can stay insulated from any legal uncertainty regarding copyrightability of code made by generative AI, and to make sure that we keep the code base easily maintainable.

In order for us to merge your PR, please confirm that all of these boxes are true when applied to this PR and check them if so:

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``black``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guideliens:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer containing the name of all generative AI models used.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.

---

This PR adds the deprecation warnings to the changes that davvid and I both currently agree upon in #591 and #597. It also updates the blacken-docs pre-commit so that pre-commit actually lets me commit this in the first place.
