### PR TITLE
Add GHA Trusted Publishing for PyPi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,42 @@ jobs:
     outputs:
       version: ${{ env.VERSION }}
       version_number: ${{ env.VERSION_NUMBER }}
+
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install build
+        run: python -m pip install --upgrade build
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/jsonpickle
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        # this tag is v1.14.0, PyPi wants us to pin to their SHA for security in case they get hijacked or something
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
   # from building the release so that we only create the release once.
   create-release:
     name: create-release
+    # only run the release flow if a maintainer pushed the tag. these two IDs
+    # are immutable and tied to the GH account, so username changes will still be fine
+    # davvid: 13196
+    # theelx: 43764914
+    if: github.actor_id == '13196' || github.actor_id == '43764914'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -42,6 +47,7 @@ jobs:
 
   build:
     name: Build distribution
+    if: github.actor_id == '13196' || github.actor_id == '43764914'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +68,7 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
+    if: github.actor_id == '13196' || github.actor_id == '43764914'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Thank you for contributing to jsonpickle! This is just a quick template for you to fill out to make sure that jsonpickle can stay insulated from any legal uncertainty regarding copyrightability of code made by generative AI, and to make sure that we keep the code base easily maintainable.

In order for us to merge your PR, please confirm that all of these boxes are true when applied to this PR and check them if so:

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``black``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guideliens:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer containing the name of all generative AI models used.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.

---

This PR adds GitHub Actions publishing to jsonpickle. I'm doing this because I remember that GPG signing for packages hasn't been enabled since like 2023, so I want to have something to build trust. PyPi introduced Trusted Publishing a while ago, and the main benefit of that is that it uses short-lived ([15-minute](https://docs.pypi.org/trusted-publishers/security-model/)) trusted API tokens, so if any long-lived credentials of ours are compromised then attackers can't just reuse them to publish. I'd recommend you revoke any keys you use to publish from twine @davvid, that way we can all rely on this.