### PR TITLE
garden: separate the "ruff check" step from the "fmt" command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ v5.0.0
       warnings. (+592)
     * Switch code styling and formatting from black to ruff. (+593)
     * Updated outdated documentation and added more usage examples (+594)
+    * ``isort`` is now an optional "testing" dependency in ``pyproject.toml``.
 
 v4.1.2
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ v5.0.0
     * Switch code styling and formatting from black to ruff. (+593)
     * Updated outdated documentation and added more usage examples (+594)
     * ``isort`` is now an optional "testing" dependency in ``pyproject.toml``.
+    * The ``garden check`` command was corrected. (+604)
 
 v4.1.2
 ======

--- a/garden.yaml
+++ b/garden.yaml
@@ -19,6 +19,7 @@ trees:
         - check/fmt
         - check/mypy
         - check/pyupgrade
+        - check/ruff
         - doc
       check/fmt: "garden fmt ${GARDEN_CMD_VERBOSE} -- --check"
       check/mypy: |
@@ -33,6 +34,9 @@ trees:
         then
             pyupgrade --py38-plus jsonpickle/*.py jsonpickle/*/*.py tests/*.py fuzzing/fuzz-targets/*.py
         fi
+      check/ruff: |
+        ${activate}
+        ruff check --fix "$@"
       clean: |
         rm -fr build dist jsonpickle.egg-info
         find . -type d -name __pycache__ -print0 | xargs -0 rm -fr
@@ -41,7 +45,6 @@ trees:
         ${activate} python3 -m sphinx docs pages
       fmt: |
         ${activate}
-        ruff check --fix "$@"
         ruff format "$@"
         isort --profile=black "$@" jsonpickle tests fuzzing/fuzz-targets
       setup: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ testing = [
     "ecdsa",
     "feedparser",
     "gmpy2",
+    "isort",
     "numpy",
     "pandas",
     "pymongo",


### PR DESCRIPTION
- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
- [N/A] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``black``.
- [N/A] If generative AI of any kind was used in creating this PR, I have followed the these guideliens:
---

Running `garden check` will run `garden fmt -- --check` in order
to invoke the `garden fmt` command in "check" mode. This breaks
because `ruff check --fix` does not support the `--check` option.

Correct the invocation.

Add `isort` to the "testing" dependencies in `pyproject.toml`.