### PR TITLE
Fix RegexHandler to preserve flags in encode/decode round-trip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ v5.0.0
       The decorative ``values`` emitted for a referenced array no longer consume a
       ``py/id`` slot, keeping the encode and decode reference counters in sync.
       (#449) (+612)
+    * Fix bug where compiled regex objects lost their flags (e.g. ``re.IGNORECASE``)
+      when roundtripped through encode/decode. (+607)
 
 v4.1.2
 ======

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -242,10 +242,11 @@ class RegexHandler(BaseHandler):
 
     def flatten(self, obj: re.Pattern[str], data: dict[str, Any]) -> HandlerReturn:
         data["pattern"] = obj.pattern
+        data["flags"] = obj.flags
         return data
 
     def restore(self, data: dict[str, Any]) -> re.Pattern[str]:
-        return re.compile(data["pattern"])
+        return re.compile(data["pattern"], data.get("flags", 0))
 
 
 RegexHandler.handles(type(re.compile("")))

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -541,6 +541,14 @@ def test_thing_with_compiled_regex(pickler, unpickler):
     assert "cat" == match.group(2)
 
 
+def test_compiled_regex_flags_roundtrip(pickler, unpickler):
+    rgx = re.compile(r"\d+\.\d+", re.IGNORECASE | re.MULTILINE)
+    flattened = pickler.flatten(rgx)
+    restored = unpickler.restore(flattened)
+    assert rgx.pattern == restored.pattern
+    assert rgx.flags == restored.flags
+
+
 def test_base_object_roundrip(pickler, unpickler):
     roundtrip = unpickler.restore(pickler.flatten(object()))
     assert type(roundtrip) is object


### PR DESCRIPTION
## Summary

`jsonpickle.encode(re.compile(pattern, re.IGNORECASE | re.MULTILINE))` followed by `decode()` silently drops all non-default flags, returning a pattern with only `re.UNICODE` set.

**Root cause:** `RegexHandler.flatten` stored only the pattern string; `restore` called `re.compile(data["pattern"])` with no flags argument.

**Fix:** Store `obj.flags` in the flattened dict and pass it to `re.compile()` on restore.

```python
# Before fix
import jsonpickle, re
pat = re.compile(r'\d+', re.IGNORECASE | re.MULTILINE)
decoded = jsonpickle.decode(jsonpickle.encode(pat))
assert decoded.flags == pat.flags  # FAILS: decoded.flags == 32, expected 42

# After fix
decoded = jsonpickle.decode(jsonpickle.encode(pat))
assert decoded.flags == pat.flags  # PASSES
```

## Changes

- `jsonpickle/handlers.py`: `RegexHandler.flatten` now stores `flags`; `restore` passes it to `re.compile`.
- `tests/object_test.py`: new test `test_compiled_regex_flags_roundtrip` covering `re.IGNORECASE | re.MULTILINE`.