### PR TITLE
Honor state_setter in 6-element __reduce__ results (fixes #608)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@ v5.0.0
     * Fix bug where objects whose state is only available through ``__reduce__``
       (such as ``datetime.timedelta``) were encoded as ``null`` when
       ``unpicklable=False``. They now fall back to a lossy representation. (#444)
+    * Fix ``ValueError: too many values to unpack (expected 5)`` when encoding or
+      decoding objects whose ``__reduce__``/``__reduce_ex__`` returns a
+      six-element tuple. The sixth ``state_setter`` element (added by pickle
+      protocol 5) is now honored. (#608)
 
 v4.1.2
 ======

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -663,13 +663,17 @@ class Pickler:
                 # pad out to len 5
                 rv_as_list = list(reduce_val)
                 insufficiency = 5 - len(rv_as_list)
-                if insufficiency:
+                if insufficiency > 0:
                     rv_as_list += [None] * insufficiency
 
                 if getattr(rv_as_list[0], "__name__", "") == "__newobj__":
                     rv_as_list[0] = tags.NEWOBJ
 
-                f, args, state, listitems, dictitems = rv_as_list
+                # A __reduce__/__reduce_ex__ result may carry a sixth
+                # ``state_setter`` element (pickle protocol 5); ``rv_as_list``
+                # keeps every element so it round-trips, but only ``state`` is
+                # needed locally.
+                f, args, state, listitems, dictitems = rv_as_list[:5]
 
                 # check that getstate/setstate is sane
                 if not (

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -670,9 +670,9 @@ class Pickler:
                     rv_as_list[0] = tags.NEWOBJ
 
                 # A __reduce__/__reduce_ex__ result may carry a sixth
-                # ``state_setter`` element (pickle protocol 5); ``rv_as_list``
-                # keeps every element so it round-trips, but only ``state`` is
-                # needed locally.
+                # state_setter element (pickle protocol 5); rv_as_list keeps
+                # every element so it round-trips, but only state is needed
+                # locally.
                 f, args, state, listitems, dictitems = rv_as_list[:5]
 
                 # check that getstate/setstate is sane

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -523,7 +523,11 @@ class Unpickler:
             return result
         if len(reduce_val) < 5:
             reduce_val.extend([None] * (5 - len(reduce_val)))
-        f, args, state, listitems, dictitems = reduce_val
+        # A __reduce__/__reduce_ex__ result may contain a sixth ``state_setter``
+        # element (added by pickle protocol 5). When present it is called as
+        # ``state_setter(obj, state)`` in place of the default state handling.
+        f, args, state, listitems, dictitems = reduce_val[:5]
+        state_setter = reduce_val[5] if len(reduce_val) > 5 else None
 
         if f == tags.NEWOBJ or getattr(f, "__name__", "") == "__newobj__":
             # mandated special case
@@ -544,7 +548,11 @@ class Unpickler:
                 # __init__ since the state dict will set all attributes immediately afterwards
                 stage1 = f.__new__(f, *args)
 
-        if state:
+        if state and state_setter is not None:
+            # pickle protocol 5: a custom state setter takes full
+            # responsibility for applying the state to the object.
+            state_setter(stage1, state)
+        elif state:
             try:
                 stage1.__setstate__(state)
             except AttributeError:

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -523,9 +523,9 @@ class Unpickler:
             return result
         if len(reduce_val) < 5:
             reduce_val.extend([None] * (5 - len(reduce_val)))
-        # A __reduce__/__reduce_ex__ result may contain a sixth ``state_setter``
+        # A __reduce__/__reduce_ex__ result may contain a sixth state_setter
         # element (added by pickle protocol 5). When present it is called as
-        # ``state_setter(obj, state)`` in place of the default state handling.
+        # state_setter(obj, state) in place of the default state handling.
         f, args, state, listitems, dictitems = reduce_val[:5]
         state_setter = reduce_val[5] if len(reduce_val) > 5 else None
 

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1523,6 +1523,31 @@ class PickleProtocol2ReduceTupleSetState(PickleProtocol2ReduceTuple):
         self.bar = state["foo"]
 
 
+def protocol_5_state_setter(obj, state):
+    """A pickle protocol 5 ``state_setter`` (the sixth ``__reduce__`` element)"""
+    obj.__dict__.update(state)
+    obj.state_setter_called = True
+
+
+class PickleProtocol5ReduceTupleStateSetter(PickleProtocol2ReduceTuple):
+    """Reducible object whose ``__reduce__`` returns a six-element tuple
+
+    The sixth element is a ``state_setter`` callable, as allowed by pickle
+    protocol 5. It is invoked as ``state_setter(obj, state)`` in place of the
+    default state handling.
+    """
+
+    def __reduce__(self):
+        return (
+            PickleProtocol2ReduceTuple,  # callable
+            ("yam", 1),  # args
+            {"foo": 1},  # state
+            iter([]),  # listitems
+            iter([]),  # dictitems
+            protocol_5_state_setter,  # state_setter (protocol 5)
+        )
+
+
 class PickleProtocol2ReduceTupleStateSlots:
     """Reducible object with tuple ``__slots__``"""
 
@@ -1714,6 +1739,30 @@ def test_reduce_state_dict():
     assert decoded.argval == "yam"
     assert decoded.optional == 1
     assert decoded.foo == 1
+
+
+def test_reduce_state_setter():
+    """Objects with a protocol 5 ``state_setter`` (6-tuple) can roundtrip"""
+    instance = PickleProtocol5ReduceTupleStateSetter(5)
+    encoded = jsonpickle.encode(instance)
+    decoded = jsonpickle.decode(encoded)
+    assert decoded.argval == "yam"
+    assert decoded.optional == 1
+    # the state_setter applied the state and recorded that it ran
+    assert decoded.foo == 1
+    assert decoded.state_setter_called is True
+
+
+def test_reduce_six_element_payload_does_not_crash(unpickler):
+    """A six-element ``py/reduce`` payload must not raise ValueError
+
+    Regression test for a ``py/reduce`` list holding the sixth ``state_setter``
+    element (pickle protocol 5). The restorer previously padded short tuples
+    and then unpacked exactly five names, so a six-element reduce raised
+    ``ValueError: too many values to unpack (expected 5)``.
+    """
+    data = {tags.REDUCE: [None, None, None, None, None, None]}
+    assert unpickler.restore(data) == []
 
 
 def test_reduce_basic():

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1524,16 +1524,16 @@ class PickleProtocol2ReduceTupleSetState(PickleProtocol2ReduceTuple):
 
 
 def protocol_5_state_setter(obj, state):
-    """A pickle protocol 5 ``state_setter`` (the sixth ``__reduce__`` element)"""
+    """A pickle protocol 5 state_setter (the sixth __reduce__ element)"""
     obj.__dict__.update(state)
     obj.state_setter_called = True
 
 
-class PickleProtocol5ReduceTupleStateSetter(PickleProtocol2ReduceTuple):
-    """Reducible object whose ``__reduce__`` returns a six-element tuple
+class Protocol5StateSetter(PickleProtocol2ReduceTuple):
+    """Reducible object whose __reduce__ returns a six-element tuple
 
-    The sixth element is a ``state_setter`` callable, as allowed by pickle
-    protocol 5. It is invoked as ``state_setter(obj, state)`` in place of the
+    The sixth element is a state_setter callable, as allowed by pickle
+    protocol 5. It is invoked as state_setter(obj, state) in place of the
     default state handling.
     """
 
@@ -1742,8 +1742,8 @@ def test_reduce_state_dict():
 
 
 def test_reduce_state_setter():
-    """Objects with a protocol 5 ``state_setter`` (6-tuple) can roundtrip"""
-    instance = PickleProtocol5ReduceTupleStateSetter(5)
+    """Objects with a protocol 5 state_setter (6-tuple) can roundtrip"""
+    instance = Protocol5StateSetter(5)
     encoded = jsonpickle.encode(instance)
     decoded = jsonpickle.decode(encoded)
     assert decoded.argval == "yam"
@@ -1754,13 +1754,7 @@ def test_reduce_state_setter():
 
 
 def test_reduce_six_element_payload_does_not_crash(unpickler):
-    """A six-element ``py/reduce`` payload must not raise ValueError
-
-    Regression test for a ``py/reduce`` list holding the sixth ``state_setter``
-    element (pickle protocol 5). The restorer previously padded short tuples
-    and then unpacked exactly five names, so a six-element reduce raised
-    ``ValueError: too many values to unpack (expected 5)``.
-    """
+    """A six-element py/reduce payload must not raise ValueError"""
     data = {tags.REDUCE: [None, None, None, None, None, None]}
     assert unpickler.restore(data) == []
 


### PR DESCRIPTION
## Summary

Fixes #608.

A `__reduce__`/`__reduce_ex__` result may be a **six-element** tuple — pickle protocol 5 added a sixth `state_setter` element, which the unpickler calls as `state_setter(obj, state)` in place of the default state handling. jsonpickle only ever handled up to five elements, so **both** the encode and decode paths crashed with `ValueError: too many values to unpack (expected 5)` on any six-element reduce.

## Reproduction (before)

Decode side (the reported case):

```python
import jsonpickle
jsonpickle.decode('{"py/reduce": [null, null, null, null, null, null]}')
# ValueError: too many values to unpack (expected 5)   @ unpickler.py:526
```

Encode side (same root cause, sibling path):

```python
import jsonpickle

def _state_setter(obj, state):
    obj.__dict__.update(state)

class WithSetter:
    def __init__(self, value=0):
        self.value = value
    def __reduce__(self):
        # 6-tuple: (callable, args, state, listitems, dictitems, state_setter)
        return (WithSetter, (), {"value": self.value}, None, None, _state_setter)

jsonpickle.encode(WithSetter(99))
# ValueError: too many values to unpack (expected 5)   @ pickler.py:672
```

Both are valid `__reduce_ex__` results — CPython's own `pickle` round-trips them fine at protocol 5.

## Root cause

Both paths pad short reduce tuples out to length 5 and then unpack exactly five names:

- `unpickler.py` `_restore_reduce`: `if len(reduce_val) < 5: reduce_val.extend(...)` then `f, args, state, listitems, dictitems = reduce_val` — a 6-element list cannot be absorbed by the 5-name unpack.
- `pickler.py` `_flatten_obj_instance`: same 5-name unpack. The pad guard `if insufficiency:` was *also* silently a no-op for six-element tuples, because `insufficiency = 5 - 6 = -1` is truthy and `list += [None] * -1` does nothing.

## Fix

- **Unpickler**: unpack `reduce_val[:5]` and read the optional sixth element as `state_setter`. When a state is present and a `state_setter` was provided, call `state_setter(stage1, state)` instead of the default `__setstate__`/`__dict__` handling — matching CPython's pickle semantics (the state setter takes full responsibility for applying the state).
- **Pickler**: unpack `rv_as_list[:5]` (the full `rv_as_list` is still flattened, so the sixth element round-trips as a `py/function`) and pad only when `insufficiency > 0`, removing the misleading no-op.

Behavior now matches the stdlib `pickle` module for protocol-5 objects with a `state_setter`:

| input | before | after (this PR) | stdlib `pickle` |
|---|---|---|---|
| `decode` 6-element `py/reduce` (all `None`) | `ValueError` | `[]` | n/a |
| encode + decode object with `state_setter` | `ValueError` on encode | value preserved, setter runs | value preserved, setter runs |

## Tests

Two regression tests added in the existing `test_reduce_*` style:

- **`test_reduce_state_setter`** — round-trips an object whose `__reduce__` returns a 6-tuple with a module-level `state_setter`; asserts the state was applied and the setter recorded that it ran. Fails on `encode` without the pickler fix and on `decode` without the unpickler fix.
- **`test_reduce_six_element_payload_does_not_crash`** — restores the exact six-element `py/reduce` payload from the issue; asserts no `ValueError`.

Proof they guard the bug (each source file stashed individually):

```
# stash unpickler.py  -> both new tests FAIL: ValueError @ unpickler.py:526
# stash pickler.py    -> test_reduce_state_setter FAILS: ValueError @ pickler.py:672
# both fixes present   -> 2 passed
```

Full suite is green with the fix:

```
tests/jsonpickle_test.py ....  176 passed
tests/ (whole dir)            380 passed, 1 skipped
ruff check                    All checks passed!
mypy --strict (unpickler/pickler)  no new errors vs. baseline
```

The changelog entry references #608 in the existing `(#NNN)` convention.
