### PR TITLE
Escape reserved tag dict keys before picklability checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ v5.0.0
       (such as ``datetime.timedelta``) were encoded as ``null`` when
       ``unpicklable=False``. They now fall back to a lossy representation. (#444)
     * Fix bug where dict keys equal to a reserved wire tag (e.g. ``py/object``,
-      ``py/id``) were silently dropped when encoding with ``keys=True``. (#611)
+      ``py/id``) were silently dropped when encoding with ``keys=True``. (+611)
 
 v4.1.2
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ v5.0.0
     * Fix bug where objects whose state is only available through ``__reduce__``
       (such as ``datetime.timedelta``) were encoded as ``null`` when
       ``unpicklable=False``. They now fall back to a lossy representation. (#444)
+    * Fix bug where dict keys equal to a reserved wire tag (e.g. ``py/object``,
+      ``py/id``) were silently dropped when encoding with ``keys=True``. (#611)
 
 v4.1.2
 ======

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -828,13 +828,24 @@ class Pickler:
         self, k: str, v: Any, data: dict[str, Any]
     ) -> dict[str, Any]:
         """Flatten string key/value pairs only."""
+        if self.keys and isinstance(k, str) and (
+            k.startswith(tags.JSON_KEY) or k in tags.RESERVED
+        ):
+            # Escape a data key that collides with the json:// escape prefix or
+            # with a reserved wire tag (e.g. "py/object", "py/id"). This must run
+            # BEFORE the _is_picklable guard below: _is_picklable rejects any
+            # name in tags.RESERVED, which is correct for object attributes but
+            # would silently DROP a legitimate user dict key here. Without the
+            # escape the key is lost on encode, and on decode _restore_from_dict
+            # skips reserved keys and the node can be misrouted (e.g. treated as
+            # a py/id).
+            data[self._escape_key(k)] = self._flatten(v)
+            return data
         if not util._is_picklable(k, v):
             return data
         if self.keys:
             if not isinstance(k, str):
                 return data
-            elif k.startswith(tags.JSON_KEY):
-                k = self._escape_key(k)
         else:
             if k is None:
                 k = "null"  # for compatibility with common json encoders

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -828,17 +828,9 @@ class Pickler:
         self, k: str, v: Any, data: dict[str, Any]
     ) -> dict[str, Any]:
         """Flatten string key/value pairs only."""
-        if self.keys and isinstance(k, str) and (
-            k.startswith(tags.JSON_KEY) or k in tags.RESERVED
-        ):
-            # Escape a data key that collides with the json:// escape prefix or
-            # with a reserved wire tag (e.g. "py/object", "py/id"). This must run
-            # BEFORE the _is_picklable guard below: _is_picklable rejects any
-            # name in tags.RESERVED, which is correct for object attributes but
-            # would silently DROP a legitimate user dict key here. Without the
-            # escape the key is lost on encode, and on decode _restore_from_dict
-            # skips reserved keys and the node can be misrouted (e.g. treated as
-            # a py/id).
+        if (k.startswith(tags.JSON_KEY) or k in tags.RESERVED) and self.keys:
+            # Escape data keys colliding with the json:// prefix or a reserved
+            # wire tag; must run before _is_picklable, which drops RESERVED keys.
             data[self._escape_key(k)] = self._flatten(v)
             return data
         if not util._is_picklable(k, v):

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -828,7 +828,11 @@ class Pickler:
         self, k: str, v: Any, data: dict[str, Any]
     ) -> dict[str, Any]:
         """Flatten string key/value pairs only."""
-        if (k.startswith(tags.JSON_KEY) or k in tags.RESERVED) and self.keys:
+        if (
+            isinstance(k, str)
+            and (k.startswith(tags.JSON_KEY) or k in tags.RESERVED)
+            and self.keys
+        ):
             # Escape data keys colliding with the json:// prefix or a reserved
             # wire tag; must run before _is_picklable, which drops RESERVED keys.
             data[self._escape_key(k)] = self._flatten(v)

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -938,12 +938,7 @@ def test_string_key_requiring_escape_dict_keys_with_keys_enabled():
 
 @pytest.mark.parametrize("reserved", sorted(tags.RESERVED))
 def test_reserved_tag_dict_keys_with_keys_enabled(reserved):
-    """A user dict key equal to a reserved wire tag round-trips verbatim.
-
-    Regression: keys such as "py/object" / "py/id" were silently dropped on
-    encode (util._is_picklable rejects any name in tags.RESERVED) and misrouted
-    on decode. They must be escaped like json:// keys under keys=True.
-    """
+    """A user dict key equal to a reserved wire tag round-trips verbatim."""
     data = {reserved: "user-value", "normal": 1}
     pickled = jsonpickle.encode(data, keys=True)
     unpickled = jsonpickle.decode(pickled, keys=True)
@@ -953,9 +948,9 @@ def test_reserved_tag_dict_keys_with_keys_enabled(reserved):
 def test_reserved_tag_dict_key_nested_in_object_with_keys_enabled():
     """A reserved-tag data key survives even inside a custom object's dict field."""
     thing = Thing("holder")
-    thing.child = {tags.OBJECT: "x", "k": 1}
+    thing.child = {tags.OBJECT: "x", "k": "cd"}
     restored = jsonpickle.decode(jsonpickle.encode(thing, keys=True), keys=True)
-    assert restored.child == {tags.OBJECT: "x", "k": 1}
+    assert restored.child == {tags.OBJECT: "x", "k": "cd"}
 
 
 def test_string_key_not_requiring_escape_dict_keys_with_keys_enabled():

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -936,6 +936,28 @@ def test_string_key_requiring_escape_dict_keys_with_keys_enabled():
     assert unpickled[tags.JSON_KEY + "6"] == [1, 2]
 
 
+@pytest.mark.parametrize("reserved", sorted(tags.RESERVED))
+def test_reserved_tag_dict_keys_with_keys_enabled(reserved):
+    """A user dict key equal to a reserved wire tag round-trips verbatim.
+
+    Regression: keys such as "py/object" / "py/id" were silently dropped on
+    encode (util._is_picklable rejects any name in tags.RESERVED) and misrouted
+    on decode. They must be escaped like json:// keys under keys=True.
+    """
+    data = {reserved: "user-value", "normal": 1}
+    pickled = jsonpickle.encode(data, keys=True)
+    unpickled = jsonpickle.decode(pickled, keys=True)
+    assert unpickled == data
+
+
+def test_reserved_tag_dict_key_nested_in_object_with_keys_enabled():
+    """A reserved-tag data key survives even inside a custom object's dict field."""
+    thing = Thing("holder")
+    thing.child = {tags.OBJECT: "x", "k": 1}
+    restored = jsonpickle.decode(jsonpickle.encode(thing, keys=True), keys=True)
+    assert restored.child == {tags.OBJECT: "x", "k": 1}
+
+
 def test_string_key_not_requiring_escape_dict_keys_with_keys_enabled():
     """String keys that do not require escaping are not escaped"""
     str_dict = {"name": [1, 2]}


### PR DESCRIPTION

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``black``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guidelines:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer containing the name of all generative AI models used.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.

---

Escape reserved tag dict keys before picklability checks.

- Prevent silent loss of dict keys equal to reserved wire tags
- Move escape earlier to catch keys before _is_picklable rejects them
- Add regression tests for reserved-tag dict keys with keys=True
