### PR TITLE
Fix numpy view py/id desync when base is shared (#449)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,11 @@ v5.0.0
       ``unpicklable=False``. They now fall back to a lossy representation. (#444)
     * Fix bug where dict keys equal to a reserved wire tag (e.g. ``py/object``,
       ``py/id``) were silently dropped when encoding with ``keys=True``. (+611)
+    * Fix bug where round-tripping a non-contiguous numpy view whose base is
+      shared with another view raised ``ValueError: strides is incompatible ...``.
+      The decorative ``values`` emitted for a referenced array no longer consume a
+      ``py/id`` slot, keeping the encode and decode reference counters in sync.
+      (#449) (+612)
 
 v4.1.2
 ======

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -288,6 +288,28 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
         super().__init__(size_threshold, compression)
         self.mode = mode
 
+    def _flatten_values_for_readability(
+        self, obj: npt.NDArray[Any], data: dict[str, Any]
+    ) -> None:
+        """Add a human-readable values entry without touching the
+        reference bookkeeping.
+
+        When an array is stored by reference to a base, the values entry is
+        purely decorative: restore reconstructs the array from base and
+        never reads it back. Flattening the values through self.context
+        would register additional py/id references that the restore step
+        does not mirror, desynchronizing the id counters and making later
+        py/id references resolve to the wrong object (see #449). Snapshot
+        and restore the reference state so the decorative flatten is a no-op as
+        far as py/id allocation is concerned.
+        """
+        context = self.context
+        saved_objs = dict(context._objs)
+        saved_flattened = dict(context._flattened)
+        super(NumpyNDArrayHandlerBinary, self).flatten(obj, data)
+        context._objs = saved_objs
+        context._flattened = saved_flattened
+
     def flatten(self, obj: npt.NDArray[Any], data: dict[str, Any]) -> dict[str, Any]:
         """encode numpy to json"""
         base = obj.base
@@ -322,7 +344,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
             if self.size_threshold is None or self.size_threshold >= obj.size:
                 # not used in restore since base is present, but
                 # include values for human-readability
-                super(NumpyNDArrayHandlerBinary, self).flatten(obj, data)
+                self._flatten_values_for_readability(obj, data)
         elif base is not None:
             try:
                 base_buf = np.frombuffer(base, dtype=np.uint8)
@@ -364,7 +386,7 @@ class NumpyNDArrayHandlerView(NumpyNDArrayHandlerBinary):
                 if self.size_threshold is None or self.size_threshold >= obj.size:
                     # not used in restore since base is present, but
                     # include values for human-readability
-                    super(NumpyNDArrayHandlerBinary, self).flatten(obj, data)
+                    self._flatten_values_for_readability(obj, data)
             else:
                 deepcopy_failed = True
         else:

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -196,8 +196,8 @@ def test_shared_base_after_referenced_object():
     """
     masked = np.ma.MaskedArray(np.array([1, 3], dtype=np.int64), mask=[False, False])
     base = np.arange(100, dtype=np.float64)
-    # Two non-contiguous views sharing ``base``. The second is stored as a
-    # ``py/id`` reference to the base emitted by the first.
+    # Two non-contiguous views sharing base. The second is stored as a
+    # py/id reference to the base emitted by the first.
     view1 = base[0::50]
     view2 = base[1::50]
     assert view1.base is base and view2.base is base

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -184,6 +184,32 @@ def test_strides():
     assert new_view.base is new_arr
 
 
+def test_shared_base_after_referenced_object():
+    """Regression test for #449.
+
+    When an object flattened earlier registers a py/id reference that is
+    not mirrored during restore (e.g. a masked array, whose decorative
+    values were previously flattened through the pickler context), the id
+    counters used by encode and decode drift apart. A later view stored as a
+    py/id reference to a shared base then resolves to the wrong object and
+    raises a strides-incompatible ValueError.
+    """
+    masked = np.ma.MaskedArray(np.array([1, 3], dtype=np.int64), mask=[False, False])
+    base = np.arange(100, dtype=np.float64)
+    # Two non-contiguous views sharing ``base``. The second is stored as a
+    # ``py/id`` reference to the base emitted by the first.
+    view1 = base[0::50]
+    view2 = base[1::50]
+    assert view1.base is base and view2.base is base
+
+    data = {"masked": masked, "view1": view1, "view2": view2}
+    actual = roundtrip(data)
+
+    npt.assert_array_equal(actual["masked"], masked)
+    npt.assert_array_equal(actual["view1"], view1)
+    npt.assert_array_equal(actual["view2"], view2)
+
+
 def test_weird_arrays():
     """Test references to arrays that do not effectively own their memory"""
     base = np.arange(9)


### PR DESCRIPTION
- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
   - [x] In the CHANGES.rst update, I added a link to the PR number that this will be (e.g. ``(+611)``) and (if applicable) added a link to the issue that this fixes (e.g. ``(#608)``).
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``ruff format``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guidelines:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer containing the name of all generative AI models used.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.
   - [x] **I understand that if I used AI and the above checkmarks are not all true when I submit this PR, my PR will be closed.**
- [x] **I understand that if this checklist is deleted from the PR body, my PR will be closed.**
---

## Summary

Fixes #449. Round-tripping a non-contiguous NumPy view whose base is shared with another view raised:

```
ValueError: strides is incompatible with shape of requested array and size of buffer
```

The maintainer confirmed an off-by-one in the encode step (a `py/id` emitted as N+1 instead of N), so the base-array reference resolved to the wrong object during restore — a 0-dim array wrapping an `unpickler._Proxy`, as reported in the issue thread.

## Root cause

When a view is stored **by reference** to a base array, `NumpyNDArrayHandlerView.flatten` also emits a decorative `values` entry, documented as *"not used in restore since base is present, but include values for human-readability"*. That decoration went through `self.context.flatten(obj.tolist(), reset=False)`, which **registers a `py/id` reference** in the pickler's bookkeeping.

Restore, however, ignores `values` entirely when a `base` is present (it rebuilds the array from `buffer`/`offset`/`strides`) and therefore never registers a matching reference. The encode and decode id counters then drift apart by one for every referenced array carrying a decorative `values`. A later view stored as `{"py/id": N}` to a shared base then resolves to the wrong object during restore, producing the strides error.

This is easy to trigger with e.g. `sklearn`'s `cv_results_` (the issue's repro): a masked array registers an unmirrored reference and the `splitN_test_score` views share a single base.

## Fix

Emit the decorative `values` **without** allocating a `py/id` slot, by snapshotting and restoring the pickler's reference bookkeeping (`_objs` / `_flattened`) around the call. This keeps the encode and decode id counters in lockstep while preserving the human-readable `values` in the output. The change is confined to the numpy extension (`jsonpickle/ext/numpy.py`); no core code is touched.

## Tests / Verification

- Added `tests/numpy_test.py::test_shared_base_after_referenced_object`, a minimal regression that reproduces the exact `ValueError` on the pristine code and passes with the fix (masked array + two non-contiguous views sharing a base).
- The original `sklearn` `cv_results_` repro from the issue now round-trips correctly with all arrays equal.
- `pytest tests/numpy_test.py tests/sklearn_test.py tests/jsonpickle_test.py` — all green (221 passed).
- Verified object-dtype views, 2D non-contiguous views, and `unpicklable=False` still round-trip correctly.
- `ruff check`, `ruff format --check`, and `isort --profile=black` are clean; `mypy --strict` introduces no new errors in the changed file.

Assisted-by: Claude (Anthropic)

Disclosure: prepared with AI assistance; reviewed and verified locally.
