### PR TITLE
Support 6-element py/reduce payloads (protocol 5 state_setter)

### DIFF
--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -521,9 +521,9 @@ class Unpickler:
             proxy.reset(result)
             self._swapref(proxy, result)
             return result
-        if len(reduce_val) < 5:
-            reduce_val.extend([None] * (5 - len(reduce_val)))
-        f, args, state, listitems, dictitems = reduce_val
+        if len(reduce_val) < 6:
+            reduce_val.extend([None] * (6 - len(reduce_val)))
+        f, args, state, listitems, dictitems, state_setter = reduce_val
 
         if f == tags.NEWOBJ or getattr(f, "__name__", "") == "__newobj__":
             # mandated special case
@@ -545,29 +545,35 @@ class Unpickler:
                 stage1 = f.__new__(f, *args)
 
         if state:
-            try:
-                stage1.__setstate__(state)
-            except AttributeError:
-                # it's fine - we'll try the prescribed default methods
+            if state_setter is not None:
+                # Protocol 5 / PEP 307's 6th reduce element: a callable
+                # that takes precedence over the default __setstate__
+                # fallback chain below.
+                state_setter(stage1, state)
+            else:
                 try:
-                    # we can't do a straight update here because we
-                    # need object identity of the state dict to be
-                    # preserved so that _swap_proxies works out
-                    for k, v in stage1.__dict__.items():
-                        state.setdefault(k, v)
-                    stage1.__dict__ = state
+                    stage1.__setstate__(state)
                 except AttributeError:
-                    # next prescribed default
+                    # it's fine - we'll try the prescribed default methods
                     try:
-                        for k, v in state.items():
-                            setattr(stage1, k, v)
-                    except Exception:
-                        dict_state, slots_state = state
-                        if dict_state:
-                            stage1.__dict__.update(dict_state)
-                        if slots_state:
-                            for k, v in slots_state.items():
+                        # we can't do a straight update here because we
+                        # need object identity of the state dict to be
+                        # preserved so that _swap_proxies works out
+                        for k, v in stage1.__dict__.items():
+                            state.setdefault(k, v)
+                        stage1.__dict__ = state
+                    except AttributeError:
+                        # next prescribed default
+                        try:
+                            for k, v in state.items():
                                 setattr(stage1, k, v)
+                        except Exception:
+                            dict_state, slots_state = state
+                            if dict_state:
+                                stage1.__dict__.update(dict_state)
+                            if slots_state:
+                                for k, v in slots_state.items():
+                                    setattr(stage1, k, v)
 
         if listitems:
             # should be lists if not None

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -356,6 +356,73 @@ def test_reduce_with_invalid_data(value, unpickler):
     assert result == []
 
 
+def test_reduce_with_six_elements_all_none(unpickler):
+    """
+    Regression test for
+    https://github.com/jsonpickle/jsonpickle/issues/608
+
+    A 6-element py/reduce (protocol 5 adds a state_setter as the 6th
+    element) must not raise ValueError from the unpack; it should be
+    handled the same way a fully-None reduce already is.
+    """
+    data = {tags.REDUCE: [None, None, None, None, None, None]}
+    result = unpickler.restore(data)
+    assert result == []
+
+
+def _six_element_reduce_state_setter(obj, state):
+    """Module-level so it can be referenced by dotted path like a real
+    pickle protocol 5 state_setter callable."""
+    obj.doubled = state["value"] * 2
+
+
+def _six_element_reduce_rebuild(value):
+    return SixElementReduceObject(value)
+
+
+class SixElementReduceObject:
+    """A reducible object whose __reduce__ returns all six protocol 5
+    elements, including a state_setter callable."""
+
+    def __init__(self, value):
+        self.value = value
+        self.doubled = None
+
+    def __reduce__(self):
+        return (
+            _six_element_reduce_rebuild,
+            (self.value,),
+            {"value": self.value},
+            None,
+            None,
+            _six_element_reduce_state_setter,
+        )
+
+
+def test_reduce_with_six_elements_state_setter_is_invoked(unpickler):
+    """
+    Regression test for
+    https://github.com/jsonpickle/jsonpickle/issues/608
+
+    The 6th py/reduce element (state_setter) must actually be called
+    to apply state, taking precedence over the default __setstate__ /
+    __dict__ fallback chain.
+    """
+    data = {
+        tags.REDUCE: [
+            {tags.FUNCTION: f"{__name__}._six_element_reduce_rebuild"},
+            [21],
+            {"value": 21},
+            None,
+            None,
+            {tags.FUNCTION: f"{__name__}._six_element_reduce_state_setter"},
+        ]
+    }
+    result = unpickler.restore(data)
+    assert result.value == 21
+    assert result.doubled == 42
+
+
 @pytest.mark.parametrize("value", ["", "x", 1, True, [], {}])
 def test_restore_id_with_invalid_data(value, unpickler):
     """Invalid serialized ID data results in None"""


### PR DESCRIPTION
Fixes #608.

`_restore_reduce()` padded reduce tuples shorter than 5 elements, then unpacked exactly 5 names: `f, args, state, listitems, dictitems`. A 6-element reduce -- valid since pickle protocol 5 added a `state_setter` as the 6th element (PEP 307 / bpo-35900) -- can't be absorbed by that 5-name unpack and raised `ValueError: too many values to unpack (expected 5)` instead of being handled, exactly as described in the issue.

**Fix**: pad to 6 elements instead of 5, unpack a 6th `state_setter` name, and when present, call it as `state_setter(obj, state)` in place of the existing `__setstate__`/`__dict__` fallback chain, matching protocol 5's semantics: `state_setter` takes precedence over the default state-application methods when supplied.

**Testing**: verified against the issue's exact reproduction (`jsonpickle.decode('{"py/reduce": [null, null, null, null, null, null]}')`) -- no longer raises, returns `[]` same as an all-`None` 5-(or fewer)-element reduce already did. Also verified with a real 6-element reduce payload referencing actual importable functions (constructed directly against the unpickler, since jsonpickle's pickler has a separate, pre-existing 5-element limit on the *encode* side that's out of scope for this decode-side issue): the `state_setter` callable is genuinely invoked and its effect is visible on the restored object, not just tolerated. Confirmed normal 5-element (or fewer) reduce payloads without a `state_setter` are completely unaffected, still going through the existing `__setstate__`/`__dict__` fallback chain exactly as before.

Added two regression tests: one for the exact all-`None` 6-element reproduction from the issue, and one constructing a full 6-element `py/reduce` payload with dotted-path function references, asserting the `state_setter`'s effect is present after restore. I confirmed both fail with the original code (`ValueError: too many values to unpack`) and pass with the fix.

Ran the full existing test suite: 374 passed (372 baseline + 2 new), 3 skipped. The one remaining failure (`test_load_backend`, missing the optional `simplejson` package) is present identically on a clean checkout of `main`, unrelated to this change.
