### PR TITLE
Preserve datetime fold through encode/decode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,10 @@ v5.0.0
       (+616)
     * Fix ``bytearray`` losing its contents through encode/decode; it now
       roundtrips like ``bytes``. (+606)
+    * Fix bug where ``datetime`` and ``time`` objects lost their PEP 495 ``fold``
+      flag when roundtripped, which changed the instant a tz-aware datetime in a
+      DST fall-back hour represented. Objects are now reduced at pickle protocol
+      4 instead of 2. (+618)
 
 v4.1.2
 ======

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -201,9 +201,9 @@ ArrayHandler.handles(array.array)
 class DatetimeHandler(BaseHandler):
     """Custom handler for datetime objects
 
-    Datetime objects use __reduce__, and they generate binary strings encoding
-    the payload. This handler encodes that payload to reconstruct the
-    object.
+    Datetime objects use __reduce_ex__, and they generate binary strings
+    encoding the payload. This handler encodes that payload to reconstruct
+    the object.
 
     """
 
@@ -215,7 +215,7 @@ class DatetimeHandler(BaseHandler):
             else:
                 result = str(obj)
             return result
-        cls, args = obj.__reduce__()  # type: ignore[str-unpack]
+        cls, args = obj.__reduce_ex__(util.PICKLE_PROTOCOL)  # type: ignore[str-unpack]
         flatten = pickler.flatten
         payload = util.b64encode(args[0])  # type: ignore[arg-type]
         args = [payload] + [flatten(i, reset=False) for i in args[1:]]

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -593,8 +593,7 @@ class Pickler:
             if has_reduce and not has_reduce_ex:
                 return obj.__reduce__()
             if has_reduce_ex:
-                # we're implementing protocol 2
-                return obj.__reduce_ex__(2)
+                return obj.__reduce_ex__(util.PICKLE_PROTOCOL)
         except TypeError:
             pass
         return None

--- a/jsonpickle/util.py
+++ b/jsonpickle/util.py
@@ -31,6 +31,9 @@ V = TypeVar("V")
 T = TypeVar("T")
 
 _ITERATOR_TYPE: type = type(iter(""))
+# Protocol used when asking objects to reduce themselves. 4 is the lowest
+# protocol that encodes datetime's PEP 495 fold bit; 2 silently drops it.
+PICKLE_PROTOCOL: int = 4
 SEQUENCES: tuple[type] = (list, set, tuple)  # type: ignore[assignment]
 SEQUENCES_SET: set[type] = {list, set, tuple}
 PRIMITIVES: set[type] = {str, bool, int, float, type(None)}

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -36,6 +36,29 @@ class UTC(datetime.tzinfo):
 utc = UTC()
 
 
+# Payloads produced by jsonpickle before the fold flag was encoded.
+LEGACY_DATETIME = (
+    '{"py/object": "datetime.datetime", "__reduce__": '
+    '[{"py/type": "datetime.datetime"}, ["B+cLBQEeAAAAAA=="]]}'
+)
+LEGACY_DATE = (
+    '{"py/object": "datetime.date", "__reduce__": '
+    '[{"py/type": "datetime.date"}, ["B+cLBQ=="]]}'
+)
+LEGACY_TIME = (
+    '{"py/object": "datetime.time", "__reduce__": '
+    '[{"py/type": "datetime.time"}, ["AR4PAeJA"]]}'
+)
+
+
+class MyDatetime(datetime.datetime):
+    """datetime subclass; no handler is registered for it"""
+
+
+class MyTime(datetime.time):
+    """time subclass; no handler is registered for it"""
+
+
 class TimestampedVariable:
     def __init__(self, value=None):
         self._value = value
@@ -159,6 +182,77 @@ def test_datetime_with_zoneinfo():
     now_us = now.replace(tzinfo=NewYork)
     _roundtrip(now_sp)
     _roundtrip(now_us)
+
+
+def test_datetime_fold():
+    """Roundtrip preserves the PEP 495 fold flag"""
+    for obj in (
+        datetime.datetime(2023, 11, 5, 1, 30, fold=1),  # ruff: ignore[DTZ001]
+        datetime.datetime(2023, 11, 5, 1, 30, tzinfo=utc, fold=1),
+        datetime.time(1, 30, fold=1),
+        datetime.time(1, 30, tzinfo=utc, fold=1),
+    ):
+        assert jsonpickle.decode(jsonpickle.encode(obj)).fold == 1
+        assert jsonpickle.decode(jsonpickle.encode(obj.replace(fold=0))).fold == 0
+
+
+def test_datetime_fold_is_encoded():
+    """fold=0 and fold=1 do not encode to the same payload"""
+    obj = datetime.datetime(2023, 11, 5, 1, 30)  # ruff: ignore[DTZ001]
+    assert jsonpickle.encode(obj) != jsonpickle.encode(obj.replace(fold=1))
+    t = datetime.time(1, 30)
+    assert jsonpickle.encode(t) != jsonpickle.encode(t.replace(fold=1))
+
+
+def test_datetime_fold_ambiguous_time():
+    """During a DST fall-back the fold flag selects the actual instant"""
+    from zoneinfo import ZoneInfo
+
+    ambiguous = [
+        (
+            ZoneInfo("America/New_York"),
+            datetime.datetime(2023, 11, 5, 1, 30),  # ruff: ignore[DTZ001]
+        ),
+        (
+            ZoneInfo("Europe/Paris"),
+            datetime.datetime(2023, 10, 29, 2, 30),  # ruff: ignore[DTZ001]
+        ),
+    ]
+    for tz, naive in ambiguous:
+        for fold in (0, 1):
+            obj = naive.replace(tzinfo=tz, fold=fold)
+            unpickled = jsonpickle.decode(jsonpickle.encode(obj))
+            # __eq__ ignores fold for same-zone operands, so compare the instants
+            assert unpickled.utcoffset() == obj.utcoffset()
+            assert unpickled.tzname() == obj.tzname()
+            assert unpickled.astimezone(datetime.timezone.utc) == obj.astimezone(
+                datetime.timezone.utc
+            )
+
+
+def test_datetime_subclass_fold():
+    """Subclasses go through py/reduce instead of the handler, but keep fold"""
+    for obj in (
+        MyDatetime(2023, 11, 5, 1, 30, fold=1),
+        MyTime(1, 30, fold=1),
+    ):
+        unpickled = jsonpickle.decode(jsonpickle.encode(obj))
+        assert type(unpickled) is type(obj)
+        assert unpickled.fold == 1
+
+
+def test_datetime_legacy_payloads():
+    """Payloads written before fold was encoded still decode"""
+    legacy = [
+        (LEGACY_DATETIME, datetime.datetime(2023, 11, 5, 1, 30)),  # ruff: ignore[DTZ001]
+        (LEGACY_DATE, datetime.date(2023, 11, 5)),
+        (LEGACY_TIME, datetime.time(1, 30, 15, 123456)),
+    ]
+    for payload, expect in legacy:
+        actual = jsonpickle.decode(payload)
+        assert actual == expect
+        assert type(actual) is type(expect)
+        assert getattr(actual, "fold", 0) == 0
 
 
 def test_struct_time():


### PR DESCRIPTION
### Problem

`fold` does not survive a roundtrip. `encode()` produces the *same bytes* for a
`datetime` with `fold=0` and `fold=1`:

```python
>>> dt = datetime.datetime(2023, 11, 5, 1, 30)
>>> jsonpickle.encode(dt) == jsonpickle.encode(dt.replace(fold=1))
True
```

For a tz-aware datetime in a DST fall-back hour that is not a cosmetic attribute
loss — `fold` is the only thing distinguishing the two real instants that share a
local clock reading, so decoding silently returns a different moment in time:

```python
>>> dt = datetime.datetime(2023, 11, 5, 1, 30,
...                        tzinfo=ZoneInfo("America/New_York"), fold=1)
>>> dt.astimezone(datetime.timezone.utc)
datetime.datetime(2023, 11, 5, 6, 30, tzinfo=datetime.timezone.utc)
>>> jsonpickle.decode(jsonpickle.encode(dt)).astimezone(datetime.timezone.utc)
datetime.datetime(2023, 11, 5, 5, 30, tzinfo=datetime.timezone.utc)   # an hour off
```

Nothing raises, and `restored == original` is still `True`, because `datetime.__eq__`
ignores `fold` for two operands in the same zone. Only `.utcoffset()` / `.tzname()` /
`.astimezone()` reveal it. `pickle.dumps`/`loads` roundtrips the same object correctly.

### Cause

`DatetimeHandler.flatten` used `obj.__reduce__()`, which CPython hard-codes to
`__reduce_ex__(2)`. The fold bit is encoded in the basestate (high bit of the month
byte for `datetime`, of the hour byte for `time`) only from **protocol 4** onwards —
protocols 0-3 always emit fold-less bytes for compatibility with pre-PEP-495
unpicklers:

```python
>>> dt.__reduce_ex__(2)[1][0].hex()
'07e70b05011e00000000'
>>> dt.__reduce_ex__(4)[1][0].hex()
'07e78b05011e00000000'    # byte 1: 0x0b -> 0x8b
```

`restore()` is not at fault; it faithfully rebuilds whatever bit pattern it is handed.

`Pickler._reduce` has the same problem (`obj.__reduce_ex__(2)`, commented
"we're implementing protocol 2"). It is the path taken by `datetime`/`time`
*subclasses*, which have no handler registered and are encoded as `py/reduce` —
they lose fold identically.

### Fix

Reduce at protocol 4 from both sites, via one `util.PICKLE_PROTOCOL` constant.

Protocol 4 rather than 5 deliberately: it is the lowest protocol that carries fold,
and it cannot produce PEP 574 out-of-band `PickleBuffer` objects. I diffed
`__reduce_ex__(2)` against protocols 3/4/5 over ~26 stdlib types (datetime family,
timedelta, timezone, ZoneInfo, Decimal, Fraction, UUID, set/frozenset, the
`collections` types, namedtuple, slice, range, `os.stat_result`, exceptions, plain
objects with and without `__getnewargs__`). Only three types reduce differently at
all: `datetime`, `time` — and `bytearray`/`array.array`, which never reach a reduce
path because they are intercepted earlier by `py/bytea` and `ArrayHandler`
respectively. So the encoded form changes for exactly the objects that were losing
data.

### Compatibility

Both directions verified, since `restore` never inspected the protocol:

* payloads written by older jsonpickle decode unchanged (fold-less bytes decode to
  `fold=0`, which is what they always meant) — pinned as a regression test with
  literal pre-change payloads;
* payloads written after this change decode correctly, *including fold*, on
  released jsonpickle 4.1.1.

`date` has no `fold` and its basestate is protocol-independent, so it is untouched.

### Tests

Five tests in `tests/datetime_test.py`: fold preservation for naive/aware
`datetime` and `time`; distinct encodings for the two fold values; the DST-ambiguous
hour in `America/New_York` and `Europe/Paris` asserted on `utcoffset`/`tzname`/
absolute UTC rather than `==`; the subclass path through `py/reduce`; and the legacy
payload decode. Red before, green after — reverting either call site alone leaves a
failing test. Full suite passes (453 passed, 1 skipped), and I checked the reduce
matrix and these tests on 3.10 through 3.14.

---

*Disclosure: I investigated and prepared this patch with the help of an AI assistant,
working under my direction. I read the CPython datetime pickling code, ran the
protocol diff and the compatibility checks, and verified the tests red then green
myself.*
