### PR TITLE
Rebuild numpy scalars from their declared dtype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,10 @@ v5.0.0
       (+616)
     * Fix ``bytearray`` losing its contents through encode/decode; it now
       roundtrips like ``bytes``. (+606)
+    * Numpy scalars are now rebuilt from their declared dtype, so ``datetime64``
+      and ``timedelta64`` keep their unit instead of silently changing resolution
+      or failing to decode, and structured and extended-precision scalars
+      roundtrip. Generalizes the nanosecond fix from (#555). (+619)
 
 v4.1.2
 ======

--- a/jsonpickle/ext/numpy.py
+++ b/jsonpickle/ext/numpy.py
@@ -62,23 +62,25 @@ class NumpyDTypeHandler(NumpyBaseHandler):
 class NumpyGenericHandler(NumpyBaseHandler):
     def flatten(self, obj: npt.NDArray[Any], data: dict[str, Any]) -> dict[str, Any]:
         self.flatten_dtype(obj.dtype.newbyteorder("N"), data)
-        data["value"] = self.context.flatten(obj.tolist(), reset=False)
+        value = obj.tolist()
+        if isinstance(value, np.generic):
+            # extended-precision scalars have no Python counterpart, so
+            # tolist() hands back the scalar itself; store its text form
+            value = str(obj)
+        data["value"] = self.context.flatten(value, reset=False)
         return data
 
-    def restore(self, data: dict[str, Any]) -> dict[str, Any]:
+    def restore(self, data: dict[str, Any]) -> Any:
         value = self.context.restore(data["value"], reset=False)
-        return self.restore_dtype(data).type(value)  # type: ignore[no-any-return]
+        # rebuild through the dtype, not dtype.type(value): the scalar
+        # constructor ignores everything the dtype carries beyond its kind,
+        # such as the datetime64/timedelta64 unit and the field layout of a
+        # structured scalar
+        return np.array(value, dtype=self.restore_dtype(data))[()]
 
 
 class NumpyDatetimeHandler(NumpyGenericHandler):
-    """Extend NumpyGenericHandler to handle nanosecond-resolution datetime64"""
-
-    def restore(self, data: dict[str, Any]) -> dict[str, Any]:
-        value = self.context.restore(data["value"], reset=False)
-        dtype = data["dtype"]
-        if dtype.endswith("[ns]"):
-            return self.restore_dtype(data).type(value, "ns")  # type: ignore[no-any-return]
-        return self.restore_dtype(data).type(value)  # type: ignore[no-any-return]
+    """Retained for backwards compatibility; datetime64 needs no special case"""
 
 
 class UnpickleableNumpyGenericHandler(NumpyGenericHandler):

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -404,35 +404,68 @@ def test_np_poly1d():
     assert obj == jsonpickle.decode(jsonpickle.encode(obj))
 
 
+TIME_UNITS = ("Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps", "fs", "as")
+
+
+def assert_scalar_roundtrip(obj):
+    """A numpy scalar must come back with its dtype intact.
+
+    Comparing datetime64/timedelta64 with == is not enough: numpy compares
+    those across units, so a lost unit still compares equal.
+    """
+    decoded = roundtrip(obj)
+    assert isinstance(decoded, np.generic), f"{type(decoded)} is not a scalar"
+    assert decoded.dtype == obj.dtype, f"{obj.dtype} became {decoded.dtype}"
+    assert_equal(decoded, obj)
+    return decoded
+
+
 def test_np_datetime64_units():
     """Ensure that we can roundtrip a numpy datetime64 with varying precisions"""
-    obj = np.datetime64("2000", "ns")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
+    for unit in TIME_UNITS:
+        # int64 attoseconds only spans ~9.2s either side of the epoch, so the
+        # stamp has to stay close to it to convert into ps/fs/as without
+        # overflowing.
+        stamp = np.datetime64("1970-01-01T00:00:01.789123456")
+        assert_scalar_roundtrip(stamp.astype(f"datetime64[{unit}]"))
+        assert_scalar_roundtrip(np.datetime64("NaT", unit))
+    assert_scalar_roundtrip(np.datetime64("NaT"))
 
-    obj = np.datetime64("2001", "ms")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
 
-    obj = np.datetime64("2002", "s")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
+def test_np_datetime64_outside_datetime_range():
+    """Dates outside the range of datetime.datetime flatten to a bare int,
+    which cannot be restored without the declared unit"""
+    # ns has ~584 years of int64 range, entirely inside datetime's, so no
+    # date outside it can be expressed in ns.
+    for unit in ("Y", "M", "W", "D", "h", "m", "s", "ms", "us"):
+        assert_scalar_roundtrip(
+            np.datetime64("30000-01-01").astype(f"datetime64[{unit}]")
+        )
 
-    obj = np.datetime64("2003", "m")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
 
-    obj = np.datetime64("2004", "h")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
+def test_np_timedelta64_units():
+    """Ensure that we can roundtrip a numpy timedelta64 with varying precisions"""
+    for unit in TIME_UNITS:
+        assert_scalar_roundtrip(np.timedelta64(7, unit))
+        assert_scalar_roundtrip(np.timedelta64(10**15, unit))
+        assert_scalar_roundtrip(np.timedelta64("NaT", unit))
+    assert_scalar_roundtrip(np.timedelta64(5))
+    assert_scalar_roundtrip(np.timedelta64("NaT"))
 
-    obj = np.datetime64("2005", "D")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
 
-    obj = np.datetime64("2006", "Y")
-    encoded = jsonpickle.encode(obj)
-    assert obj == jsonpickle.decode(encoded)
+def test_np_structured_scalar_roundtrip():
+    """A structured scalar carries its field layout in the dtype, not the value"""
+    dtype = [("a", "i4"), ("b", "f8"), ("c", "S3")]
+    decoded = assert_scalar_roundtrip(np.array([(1, 2.5, b"xy")], dtype=dtype)[0])
+    assert decoded["a"] == 1
+    assert decoded["c"] == b"xy"
+
+
+def test_np_extended_precision_scalar_roundtrip():
+    """longdouble has no Python counterpart, so tolist() returns the scalar
+    itself rather than a float"""
+    assert_scalar_roundtrip(np.longdouble("1.1"))
+    assert_scalar_roundtrip(np.clongdouble(complex(1.1, 2.0)))
 
 
 def test_np_ufuncs():


### PR DESCRIPTION
### Problem

`datetime64` and `timedelta64` scalars do not keep their unit through a roundtrip,
and for most units they do not decode at all:

```python
>>> jsonpickle.decode(jsonpickle.encode(np.datetime64("2020-06-15T12", "h"))).dtype
dtype('<M8[us]')                      # declared [h]
>>> jsonpickle.decode(jsonpickle.encode(np.timedelta64(7, "D")))
np.timedelta64(604800000000,'us')     # declared [D]
>>> jsonpickle.decode(jsonpickle.encode(np.datetime64("30000-01-01")))
ValueError: Converting an integer to a NumPy datetime requires a specified unit
```

The silent case is easy to miss because numpy compares `datetime64`/`timedelta64`
across units, so `decoded == original` stays `True` — which is all
`test_np_datetime64_units` asserted.

### Cause

`NumpyGenericHandler.restore` rebuilds the scalar with `dtype.type(value)`. The
scalar constructor takes only the kind, so numpy re-infers the unit from whatever
Python type `.tolist()` happened to produce: `datetime.date` → `D`,
`datetime.datetime` → `us`, bare `int` → the ValueError above. Everything the
dtype declares beyond its kind is dropped, even though it is sitting right there
in `data["dtype"]`.

#556 fixed the `ns` case by passing `"ns"` explicitly, on the reading that "other
units do not require special handling". Structured scalars fail on the same line
for the same reason from the other side: `np.void((1, 2.5))` wants bytes, so a
record scalar never decodes at all.

I put every numpy scalar type and every time unit through encode/decode and
compared against `pickle`, which is exact for numpy scalars: **52 of 77 cases
diverge**. Every unit of both temporal types is affected except `datetime64[ns]`,
the one #556 covered — `datetime64[D|us]` and `timedelta64[us]` survive an
in-range value by coincidence of which Python type `.tolist()` returns, but still
lose the unit on `NaT` or fail on a date outside `datetime.datetime`'s range.

### Fix

Build the scalar through the dtype instead of through `dtype.type`, so the unit
and the field layout come along, and drop the `ns` special case. The 77-case
comparison against `pickle` is then clean.

The audit turned up one more gap, on the flatten side: `longdouble` and
`clongdouble` have no Python counterpart, so `.tolist()` returns the scalar itself
and `jsonpickle.encode(np.longdouble(1.1))` recurses until the interpreter gives
up. Those two store their text form instead. Every other scalar type is
unaffected — I checked all 24 of them, `.tolist()` is Python-native for the rest.

### Tests

`test_np_datetime64_units` now loops over all 13 units and asserts the dtype
rather than just `==`; new tests cover `timedelta64` (which had no coverage at
all), values outside `datetime.datetime`'s range, structured scalars and extended
precision. All five fail on `main`. Full suite 407 passed / 5 skipped;
`ruff format` and `mypy ./jsonpickle` clean (same 5 pre-existing pandas-stubs
errors as on `main`).

---

*Disclosure: I investigated and prepared this patch with the help of an AI
assistant, working under my direction. The change is confined to the numpy
extension; I reviewed the handler, ran the differential audit against `pickle`
and verified the tests red then green myself.*
