### PR TITLE
Add more extensive benchmarking suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /images/benchmark-*.svg
 /images/benchmark-data
 /images/benchmark-compare*.png
+/images/benchmark-summary*.png
 /benchmarking/*_old*.py
 /benchmarking/images/
 /metrics/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ monkeytype.sqlite3
 # benchmarking code
 .bench-venvs/
 .bench-worktrees/
+/benchmarking/.bench-common-tests.json

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ v5.0.0
       and ``timedelta64`` keep their unit instead of silently changing resolution
       or failing to decode, and structured and extended-precision scalars
       roundtrip. Generalizes the nanosecond fix from (#555). (+619)
+    * The ability to run benchmarks over the entire pytest suite has been added
+      in order to cover a wider portion of the codebase with the benchmarks. (+620)
 
 v4.1.2
 ======

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,13 @@ endif
 flags ?=
 
 # Capture extra arguments for the benchmark target
-EXTRA_BENCH_ARGS ?= 
+EXTRA_BENCH_ARGS ?=
+
+# Test files to benchmark concurrently in the benchmark_big target. Each job gets
+# its own physical core. Defaults to 1 because concurrent jobs still share L3 and
+# memory bandwidth, so their timings are only comparable to other parallel runs.
+# Values above half the machine's CPU count are clamped down to that.
+BENCH_JOBS ?= 1
 
 # Default job count -- this is used if "-j" is not present in MAKEFLAGS.
 nproc := $(shell sh -c '$(NPROC) 2>/dev/null || echo 4')
@@ -70,6 +76,8 @@ help::
 	@echo "make tox            - run unit tests using tox"
 	@echo "make clean          - remove cruft"
 	@echo "make benchmark      - run pytest benchmarking"
+	@echo "make benchmark_big  - run pytest benchmarking over the whole test suite"
+	@echo "                      (pass BENCH_JOBS=N to benchmark N files at once)"
 	@echo "make doc            - generate documentation using sphinx"
 .PHONY: help
 
@@ -134,6 +142,22 @@ benchmark::
 		echo "The 'benchmark' target has much less noise on Linux, try running it on there!"; \
 	fi
 .PHONY: benchmark
+
+# Benchmark every test in tests/ instead of the smaller suite in jsonpickle_benchmarks.py
+benchmark_big::
+	@cd $(CURDIR)/benchmarking && \
+	JSONPICKLE_BENCH_TAG=local \
+	JSONPICKLE_EXPECT_VERSION=local \
+	JSONPICKLE_EXPECT_PATH=$(CURDIR)/jsonpickle \
+	JSONPICKLE_BENCH_OUTPUT_ROOT=$(CURDIR) \
+	JSONPICKLE_TESTS_DIR=$(CURDIR)/tests \
+	JSONPICKLE_PYTEST_CONFIG=$(CURDIR)/pytest.ini \
+	JSONPICKLE_ROOTDIR=`mktemp -d` \
+	JSONPICKLE_BENCH_JOBS=$(BENCH_JOBS) \
+	PYTHONPATH=$(CURDIR) \
+	PYTHONNOUSERSITE=1 \
+	$(PYTHON) ./jsonpickle_pytest_benchmarks.py $(EXTRA_BENCH_ARGS)
+.PHONY: benchmark_big
 
 doc::
 	$(SPHINX) docs build/html

--- a/benchmarking/.bench-pytest.ini
+++ b/benchmarking/.bench-pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts=
+python_functions = test_* simple_* complex_* state_*

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -21,3 +21,9 @@ This core tends to be one of the lesser-used ones on your system, assuming you h
 ### Actually running the code
 You can just run ``make benchmark`` in the root of the project, and it will automatically do as much as it can to ensure a reproducible setup, and easy-to-visualize results! It should output a histogram of the results in the images/ directory.
 Another thing you can do is ``cd benchmarking && ./analyze_benchmarks.sh``. This will compare the mean speed for each benchmark between the current branch that you're working on, and the main branch, so you can check improvements or regressions.
+
+### Benchmarking the whole test suite
+``make benchmark_big`` benchmarks every test in ``tests/`` instead of the smaller suite in ``jsonpickle_benchmarks.py``, one file at a time (pass ``BENCH_JOBS=N`` to run N files at once, each pinned to its own physical core).
+
+``python3 benchmarking/benchmark_versions.py 3.0.0,3.1.0`` benchmarks your working tree against released versions in their own venvs, using only the tests that every version has in common.
+It writes one box and whisker plot per version, plus ``images/benchmark-compare-<timestamp>.png``, which reduces every shared test in the suite down to one geometric mean per version so you can see the overall change at a glance.

--- a/benchmarking/benchmark_versions.py
+++ b/benchmarking/benchmark_versions.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sys
@@ -131,35 +132,63 @@ def _ensure_min_pytest_config() -> Path:
     return MIN_PYTEST_CONFIG
 
 
-def _run_benchmarks(version: str, python: Path, worktree: Path) -> None:
+def _env_for(version: str, worktree: Path | None) -> dict[str, str]:
     env = os.environ.copy()
     env["JSONPICKLE_BENCH_TAG"] = version
     env["JSONPICKLE_EXPECT_VERSION"] = version
-    env["JSONPICKLE_EXPECT_PATH"] = str((worktree / "jsonpickle").resolve())
     env["JSONPICKLE_BENCH_OUTPUT_ROOT"] = str(ROOT)
-    env["JSONPICKLE_TESTS_DIR"] = str(worktree / "tests")
-    # avoid old pytest.ini options that require missing plugins
-    env["JSONPICKLE_PYTEST_CONFIG"] = str(_ensure_min_pytest_config())
-    env["JSONPICKLE_ROOTDIR"] = str(worktree / "tests")
-    env["PYTHONPATH"] = os.pathsep.join([str(worktree), str(worktree / "tests")])
     env["PYTHONNOUSERSITE"] = "1"
-    work_dir = str(ROOT / "benchmarking")
-    run([str(python), str(BENCH_SCRIPT)], check=False, cwd=work_dir, env=env)
+    if worktree is None:
+        env["JSONPICKLE_EXPECT_PATH"] = str((ROOT / "jsonpickle"))
+        env["JSONPICKLE_TESTS_DIR"] = str(ROOT / "tests")
+        env["JSONPICKLE_PYTEST_CONFIG"] = str(ROOT / "pytest.ini")
+        env["JSONPICKLE_ROOTDIR"] = tempfile.mkdtemp(prefix="jsonpickle-bench-root-")
+        env["PYTHONPATH"] = str(ROOT)
+    else:
+        env["JSONPICKLE_EXPECT_PATH"] = str((worktree / "jsonpickle").resolve())
+        env["JSONPICKLE_TESTS_DIR"] = str(worktree / "tests")
+        # avoid old pytest.ini options that require missing plugins
+        env["JSONPICKLE_PYTEST_CONFIG"] = str(_ensure_min_pytest_config())
+        env["JSONPICKLE_ROOTDIR"] = str(worktree / "tests")
+        env["PYTHONPATH"] = os.pathsep.join([str(worktree), str(worktree / "tests")])
+    return env
 
 
-def _run_benchmarks_local() -> None:
-    env = os.environ.copy()
-    env["JSONPICKLE_BENCH_TAG"] = "local"
-    env["JSONPICKLE_EXPECT_VERSION"] = "local"
-    env["JSONPICKLE_EXPECT_PATH"] = str((ROOT / "jsonpickle"))
-    env["JSONPICKLE_BENCH_OUTPUT_ROOT"] = str(ROOT)
-    env["JSONPICKLE_TESTS_DIR"] = str(ROOT / "tests")
-    env["JSONPICKLE_PYTEST_CONFIG"] = str(ROOT / "pytest.ini")
-    env["JSONPICKLE_ROOTDIR"] = tempfile.mkdtemp(prefix="jsonpickle-bench-root-")
-    env["PYTHONPATH"] = str(ROOT)
-    env["PYTHONNOUSERSITE"] = "1"
+def _collect_tests(version: str, python: Path, worktree: Path | None) -> set[str]:
+    """
+    Return the test keys this version's suite contains, without timing them.
+    This is useful for ensuring that all tested versions test the same tests.
+    """
+    interpreter = str(python) if worktree is not None else sys.executable
+    env = _env_for(version, worktree)
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as handle:
+        target = Path(handle.name)
+    env["JSONPICKLE_BENCH_COLLECT"] = str(target)
+    result = run(
+        [interpreter, str(BENCH_SCRIPT)],
+        check=False,
+        cwd=str(ROOT / "benchmarking"),
+        env=env,
+    )
+    if result.returncode != 0:
+        print(f"Warning: collection for {version} exited with {result.returncode}")
+    try:
+        keys = set(json.loads(target.read_text(encoding="utf-8")))
+    except (OSError, ValueError):
+        print(f"Warning: no collected tests for {version}")
+        keys = set()
+    target.unlink(missing_ok=True)
+    return keys
+
+
+def _run_benchmarks(
+    version: str, python: Path | None, worktree: Path | None, only: Path
+) -> None:
+    interpreter = str(python) if worktree is not None else sys.executable
+    env = _env_for(version, worktree)
+    env["JSONPICKLE_BENCH_ONLY"] = str(only)
     run(
-        [sys.executable, str(BENCH_SCRIPT)],
+        [interpreter, str(BENCH_SCRIPT)],
         check=False,
         cwd=str(ROOT / "benchmarking"),
         env=env,
@@ -186,26 +215,48 @@ def _load_benchmarks_for(version: str) -> dict[str, dict[str, float]]:
     return per_file
 
 
+def _geometric_mean(values: list[float]) -> float:
+    """
+    Benchmark times are on the order of 1e-5 seconds, so multiplying a few
+    hundred of them together would flush to zero long before we took the root.
+    Therefore, we compute it in log-space.
+    """
+    return math.exp(math.fsum(math.log(value) for value in values) / len(values))
+
+
 def _compute_file_means(
-    baseline: str,
     versions: list[str],
     series: dict[str, dict[str, dict[str, float]]],
 ) -> dict[str, dict[str, float]]:
+    file_names: set[str] = set()
+    for version in versions:
+        file_names.update(series.get(version, {}))
+
     result: dict[str, dict[str, float]] = {}
-    baseline_files = series.get(baseline, {})
-    for file_name, baseline_tests in baseline_files.items():
-        baseline_set = set(baseline_tests.keys())
-        if not baseline_set:
+    for file_name in sorted(file_names):
+        per_version = [series.get(v, {}).get(file_name, {}) for v in versions]
+        missing = [v for v, tests in zip(versions, per_version) if not tests]
+        if missing:
+            print(f"Skipping {file_name}: no data for {', '.join(missing)}")
             continue
-        for version in versions:
-            tests = series.get(version, {}).get(file_name, {})
-            if not tests:
-                continue
-            common = baseline_set.intersection(tests.keys())
-            if not common:
-                continue
-            values = [tests[name] for name in common]
-            result.setdefault(version, {})[file_name] = sum(values) / len(values)
+        common = set(per_version[0])
+        for tests in per_version[1:]:
+            common &= set(tests)
+        # log() needs strictly positive input, and a zero-length timing is junk
+        # data anyway, so drop those tests rather than crashing on them
+        common = {
+            name for name in common if all(tests[name] > 0 for tests in per_version)
+        }
+        if not common:
+            print(f"Skipping {file_name}: no tests shared by every version")
+            continue
+        dropped = max(len(tests) for tests in per_version) - len(common)
+        if dropped:
+            print(f"{file_name}: comparing {len(common)} tests, ignoring {dropped}")
+        for version, tests in zip(versions, per_version):
+            result.setdefault(version, {})[file_name] = _geometric_mean(
+                [tests[name] for name in common]
+            )
     return result
 
 
@@ -239,7 +290,7 @@ def _plot_deltas(
     ax.axhline(1.0, color="black", linewidth=0.8)
     ax.set_xticks([i + width * (len(versions) / 2) for i in x])
     ax.set_xticklabels(labels, rotation=45, ha="right")
-    ax.set_ylabel("Time relative to baseline (baseline = 1.0)")
+    ax.set_ylabel("Geomean time relative to baseline (baseline = 1.0)")
     ax.set_title(f"jsonpickle benchmark time ratios vs {baseline}")
     ax.legend()
     fig.tight_layout()
@@ -272,16 +323,36 @@ def main() -> int:
     DATA_DIR.mkdir(exist_ok=True)
 
     tags = _git_tags()
-    _run_benchmarks_local()
+    targets: list[tuple[str, Path | None, Path | None]] = [("local", None, None)]
     for version in versions:
         tag = _resolve_tag(version, tags)
         worktree = _ensure_worktree(tag)
         python = _ensure_venv(version)
-        _run_benchmarks(version, python, worktree)
+        targets.append((version, python, worktree))
+
+    # benchmarking a test that only some versions have is wasted time,
+    # and averaging it in would skew the result
+    collected = {
+        version: _collect_tests(version, python, worktree)
+        for version, python, worktree in targets
+    }
+    common = set.intersection(*collected.values()) if collected else set()
+    if not common:
+        print("No tests are shared by every version under test!", file=sys.stderr)
+        return
+    for version, keys in collected.items():
+        if len(keys) > len(common):
+            print(f"{version}: benchmarking {len(common)} of {len(keys)} tests")
+
+    only = ROOT / "benchmarking" / ".bench-common-tests.json"
+    only.write_text(json.dumps(sorted(common)), encoding="utf-8")
+
+    for version, python, worktree in targets:
+        _run_benchmarks(version, python, worktree, only)
 
     versions_all = ["local", *versions]
     raw = {version: _load_benchmarks_for(version) for version in versions_all}
-    series = _compute_file_means("local", versions_all, raw)
+    series = _compute_file_means(versions_all, raw)
     output = _plot_deltas("local", versions_all, series)
 
     if args.output:

--- a/benchmarking/benchmark_versions.py
+++ b/benchmarking/benchmark_versions.py
@@ -1,5 +1,9 @@
 """
-Benchmark multiple jsonpickle versions and plot per-file performance deltas.
+Benchmark multiple jsonpickle versions and plot how they compare.
+
+Every version gets one box and whisker plot over its per-file timings, and the
+run ends with a single comparison plot of the whole suite's geometric mean for
+each version.
 
 Usage: python3 benchmarking/benchmark_versions.py 3.0.0,3.1.0,3.2.0
 
@@ -11,7 +15,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import re
 import sys
@@ -22,6 +25,14 @@ from subprocess import run
 from venv import EnvBuilder
 
 import matplotlib.pyplot as plt
+
+# the benchmark runner lives next to this file and owns the shared plotting code
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from jsonpickle_pytest_benchmarks import (
+    geometric_mean,
+    plot_file_summary,
+    print_file_summary,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 BENCH_SCRIPT = ROOT / "benchmarking" / "jsonpickle_pytest_benchmarks.py"
@@ -215,24 +226,15 @@ def _load_benchmarks_for(version: str) -> dict[str, dict[str, float]]:
     return per_file
 
 
-def _geometric_mean(values: list[float]) -> float:
-    """
-    Benchmark times are on the order of 1e-5 seconds, so multiplying a few
-    hundred of them together would flush to zero long before we took the root.
-    Therefore, we compute it in log-space.
-    """
-    return math.exp(math.fsum(math.log(value) for value in values) / len(values))
-
-
-def _compute_file_means(
+def _shared_tests(
     versions: list[str],
     series: dict[str, dict[str, dict[str, float]]],
-) -> dict[str, dict[str, float]]:
+) -> dict[str, dict[str, list[float]]]:
     file_names: set[str] = set()
     for version in versions:
         file_names.update(series.get(version, {}))
 
-    result: dict[str, dict[str, float]] = {}
+    result: dict[str, dict[str, list[float]]] = {version: {} for version in versions}
     for file_name in sorted(file_names):
         per_version = [series.get(v, {}).get(file_name, {}) for v in versions]
         missing = [v for v, tests in zip(versions, per_version) if not tests]
@@ -253,51 +255,90 @@ def _compute_file_means(
         dropped = max(len(tests) for tests in per_version) - len(common)
         if dropped:
             print(f"{file_name}: comparing {len(common)} tests, ignoring {dropped}")
+        ordered = sorted(common)
         for version, tests in zip(versions, per_version):
-            result.setdefault(version, {})[file_name] = _geometric_mean(
-                [tests[name] for name in common]
-            )
+            result[version][file_name] = [tests[name] for name in ordered]
     return result
 
 
-def _plot_deltas(
-    baseline: str, versions: list[str], series: dict[str, dict[str, float]]
+def _plot_version_summaries(
+    shared: dict[str, dict[str, list[float]]], timestamp: str
+) -> list[Path]:
+    outputs = []
+    for version, per_file in shared.items():
+        if not per_file:
+            print(f"Skipping the summary plot for {version}: no shared test data")
+            continue
+        print_file_summary(per_file, header=f"{version} benchmark summary")
+        output = plot_file_summary(
+            per_file,
+            f"jsonpickle {version} test suite benchmark summary",
+            IMAGES_DIR / f"benchmark-summary-{timestamp}-{_sanitize_tag(version)}.png",
+        )
+        if output is not None:
+            outputs.append(output)
+            print(f"Saved the {version} summary plot to {output}")
+    return outputs
+
+
+def _suite_geomeans(shared: dict[str, dict[str, list[float]]]) -> dict[str, float]:
+    """
+    Collapse every shared test in the suite down to one number per version.
+    """
+    result = {}
+    for version, per_file in shared.items():
+        values = [mean for means in per_file.values() for mean in means]
+        if values:
+            result[version] = geometric_mean(values)
+    return result
+
+
+def _plot_comparison(
+    baseline: str,
+    versions: list[str],
+    suite: dict[str, float],
+    test_count: int,
+    timestamp: str,
 ) -> Path:
-    files = sorted(series.get(baseline, {}).keys())
-    if not files:
+    labels = [version for version in versions if version in suite]
+    if not labels:
         raise RuntimeError("No benchmark data found to plot")
 
-    baseline_stats = series.get(baseline, {})
-    labels = files
-    x = range(len(labels))
-    width = 0.8 / max(len(versions), 1)
+    values = [suite[version] * 1e6 for version in labels]
+    base = suite.get(baseline)
 
-    fig, ax = plt.subplots(figsize=(max(8, len(labels) * 0.6), 5))
-    offset = 0
-    for version in versions:
-        values = []
-        for file_name in labels:
-            base = baseline_stats.get(file_name)
-            cur = series.get(version, {}).get(file_name)
-            if base is None or cur is None:
-                values.append(float("nan"))
-            else:
-                values.append(cur / base)
-        positions = [i + offset for i in x]
-        ax.bar(positions, values, width=width, label=version)
-        offset += width
+    fig, ax = plt.subplots(figsize=(max(6, len(labels) * 1.4), 5))
+    bars = ax.bar(range(len(labels)), values, width=0.6, color="#3b6fb0")
+    for version, value, bar in zip(labels, values, bars):
+        text = f"{value:.3f}us"
+        if base:
+            text += f"\n{suite[version] / base:.3f}x"
+        ax.annotate(
+            text,
+            (bar.get_x() + bar.get_width() / 2, bar.get_height()),
+            textcoords="offset points",
+            xytext=(0, 4),
+            ha="center",
+            fontsize=9,
+            color="#3c4450",
+        )
 
-    ax.axhline(1.0, color="black", linewidth=0.8)
-    ax.set_xticks([i + width * (len(versions) / 2) for i in x])
-    ax.set_xticklabels(labels, rotation=45, ha="right")
-    ax.set_ylabel("Geomean time relative to baseline (baseline = 1.0)")
-    ax.set_title(f"jsonpickle benchmark time ratios vs {baseline}")
-    ax.legend()
+    ax.set_xticks(range(len(labels)))
+    ax.set_xticklabels(labels)
+    ax.set_ylabel("Geometric mean time per test (microseconds)")
+    # two lines because one long title runs off the end of a narrow figure
+    subtitle = f"over {test_count} tests shared by every version"
+    if base:
+        subtitle += f" (x = ratio to {baseline})"
+    ax.set_title(f"jsonpickle suite-wide benchmark geomean\n{subtitle}")
+    ax.grid(axis="y", color="#d7dbe0", linewidth=0.6)
+    ax.set_axisbelow(True)
+    ax.margins(y=0.15)
     fig.tight_layout()
 
-    timestamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H%M%S%z")
     output = IMAGES_DIR / f"benchmark-compare-{timestamp}.png"
-    fig.savefig(output)
+    fig.savefig(output, dpi=150)
+    plt.close(fig)
     return output
 
 
@@ -352,8 +393,17 @@ def main() -> int:
 
     versions_all = ["local", *versions]
     raw = {version: _load_benchmarks_for(version) for version in versions_all}
-    series = _compute_file_means(versions_all, raw)
-    output = _plot_deltas("local", versions_all, series)
+    shared = _shared_tests(versions_all, raw)
+    timestamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H%M%S%z")
+    _plot_version_summaries(shared, timestamp)
+
+    suite = _suite_geomeans(shared)
+    test_count = sum(len(means) for means in shared[versions_all[0]].values())
+    print("\n===== suite-wide geomean =====")
+    for version in versions_all:
+        if version in suite:
+            print(f"{version}: {suite[version] * 1e6:.3f}us over {test_count} tests")
+    output = _plot_comparison("local", versions_all, suite, test_count, timestamp)
 
     if args.output:
         target = Path(args.output)

--- a/benchmarking/benchmark_versions.py
+++ b/benchmarking/benchmark_versions.py
@@ -150,7 +150,7 @@ def _env_for(version: str, worktree: Path | None) -> dict[str, str]:
     env["JSONPICKLE_BENCH_OUTPUT_ROOT"] = str(ROOT)
     env["PYTHONNOUSERSITE"] = "1"
     if worktree is None:
-        env["JSONPICKLE_EXPECT_PATH"] = str((ROOT / "jsonpickle"))
+        env["JSONPICKLE_EXPECT_PATH"] = str(ROOT / "jsonpickle")
         env["JSONPICKLE_TESTS_DIR"] = str(ROOT / "tests")
         env["JSONPICKLE_PYTEST_CONFIG"] = str(ROOT / "pytest.ini")
         env["JSONPICKLE_ROOTDIR"] = tempfile.mkdtemp(prefix="jsonpickle-bench-root-")

--- a/benchmarking/benchmark_versions.py
+++ b/benchmarking/benchmark_versions.py
@@ -1,0 +1,298 @@
+"""
+Benchmark multiple jsonpickle versions and plot per-file performance deltas.
+
+Usage: python3 benchmarking/benchmark_versions.py 3.0.0,3.1.0,3.2.0
+
+Requires matplotlib in the current environment and internet access that can reach PyPi
+to install jsonpickle into the per-version venvs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from subprocess import run
+from venv import EnvBuilder
+
+import matplotlib.pyplot as plt
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCH_SCRIPT = ROOT / "benchmarking" / "jsonpickle_pytest_benchmarks.py"
+IMAGES_DIR = ROOT / "images"
+DATA_DIR = IMAGES_DIR / "benchmark-data"
+WORKTREE_DIR = ROOT / ".bench-worktrees"
+MIN_PYTEST_CONFIG = ROOT / "benchmarking" / ".bench-pytest.ini"
+
+
+def _sanitize_tag(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
+
+
+def _venv_dir_for(version: str) -> Path:
+    safe = _sanitize_tag(version)
+    return ROOT / ".bench-venvs" / f"jsonpickle-{safe}"
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _ensure_venv(version: str) -> Path:
+    venv_dir = _venv_dir_for(version)
+    if not venv_dir.exists():
+        EnvBuilder(with_pip=True).create(venv_dir)
+    python = _venv_python(venv_dir)
+    run([str(python), "-m", "pip", "install", "-U", "pip"], check=True)
+    run(
+        [
+            str(python),
+            "-m",
+            "pip",
+            "install",
+            "pytest",
+            "pytest-benchmark[histogram]",
+            "pygal",
+            "pygaljs",
+            "matplotlib",
+            "numpy",
+            "scikit-learn",
+            "pandas",
+            "pymongo",
+            "ecdsa",
+        ],
+        check=True,
+    )
+    return python
+
+
+def _git_tags() -> set[str]:
+    result = run(
+        ["git", "-C", str(ROOT), "tag", "--list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _resolve_tag(version: str, tags: set[str]) -> str:
+    if version in tags:
+        return version
+    candidate = f"v{version}"
+    if candidate in tags:
+        return candidate
+    raise RuntimeError(f"No git tag found for version {version}")
+
+
+def _ensure_worktree(tag: str) -> Path:
+    WORKTREE_DIR.mkdir(exist_ok=True)
+    worktree = WORKTREE_DIR / f"jsonpickle-{_sanitize_tag(tag)}"
+    if worktree.exists():
+        current = run(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        target = run(
+            ["git", "-C", str(ROOT), "rev-parse", tag],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if current == target:
+            return worktree
+        run(
+            ["git", "-C", str(ROOT), "worktree", "remove", "--force", str(worktree)],
+            check=True,
+        )
+    run(
+        ["git", "-C", str(ROOT), "worktree", "add", "--force", str(worktree), tag],
+        check=True,
+    )
+    return worktree
+
+
+def _ensure_min_pytest_config() -> Path:
+    if MIN_PYTEST_CONFIG.exists():
+        return MIN_PYTEST_CONFIG
+    MIN_PYTEST_CONFIG.write_text(
+        "[pytest]\naddopts=\npython_functions = test_* simple_* complex_* state_*\n",
+        encoding="utf-8",
+    )
+    return MIN_PYTEST_CONFIG
+
+
+def _run_benchmarks(version: str, python: Path, worktree: Path) -> None:
+    env = os.environ.copy()
+    env["JSONPICKLE_BENCH_TAG"] = version
+    env["JSONPICKLE_EXPECT_VERSION"] = version
+    env["JSONPICKLE_EXPECT_PATH"] = str((worktree / "jsonpickle").resolve())
+    env["JSONPICKLE_BENCH_OUTPUT_ROOT"] = str(ROOT)
+    env["JSONPICKLE_TESTS_DIR"] = str(worktree / "tests")
+    # avoid old pytest.ini options that require missing plugins
+    env["JSONPICKLE_PYTEST_CONFIG"] = str(_ensure_min_pytest_config())
+    env["JSONPICKLE_ROOTDIR"] = str(worktree / "tests")
+    env["PYTHONPATH"] = os.pathsep.join([str(worktree), str(worktree / "tests")])
+    env["PYTHONNOUSERSITE"] = "1"
+    work_dir = str(ROOT / "benchmarking")
+    run([str(python), str(BENCH_SCRIPT)], check=False, cwd=work_dir, env=env)
+
+
+def _run_benchmarks_local() -> None:
+    env = os.environ.copy()
+    env["JSONPICKLE_BENCH_TAG"] = "local"
+    env["JSONPICKLE_EXPECT_VERSION"] = "local"
+    env["JSONPICKLE_EXPECT_PATH"] = str((ROOT / "jsonpickle"))
+    env["JSONPICKLE_BENCH_OUTPUT_ROOT"] = str(ROOT)
+    env["JSONPICKLE_TESTS_DIR"] = str(ROOT / "tests")
+    env["JSONPICKLE_PYTEST_CONFIG"] = str(ROOT / "pytest.ini")
+    env["JSONPICKLE_ROOTDIR"] = tempfile.mkdtemp(prefix="jsonpickle-bench-root-")
+    env["PYTHONPATH"] = str(ROOT)
+    env["PYTHONNOUSERSITE"] = "1"
+    run(
+        [sys.executable, str(BENCH_SCRIPT)],
+        check=False,
+        cwd=str(ROOT / "benchmarking"),
+        env=env,
+    )
+
+
+def _load_benchmarks_for(version: str) -> dict[str, dict[str, float]]:
+    tag = _sanitize_tag(version)
+    per_file: dict[str, dict[str, float]] = {}
+    if not DATA_DIR.exists():
+        return {}
+    for path in DATA_DIR.rglob("*.json"):
+        if tag not in path.name:
+            continue
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        for bench in payload.get("benchmarks", []):
+            group = bench.get("group") or "unknown"
+            name = bench.get("name") or bench.get("fullname") or "unknown"
+            mean = bench.get("stats", {}).get("mean")
+            if mean is None:
+                continue
+            per_file.setdefault(group, {})[name] = mean
+    return per_file
+
+
+def _compute_file_means(
+    baseline: str,
+    versions: list[str],
+    series: dict[str, dict[str, dict[str, float]]],
+) -> dict[str, dict[str, float]]:
+    result: dict[str, dict[str, float]] = {}
+    baseline_files = series.get(baseline, {})
+    for file_name, baseline_tests in baseline_files.items():
+        baseline_set = set(baseline_tests.keys())
+        if not baseline_set:
+            continue
+        for version in versions:
+            tests = series.get(version, {}).get(file_name, {})
+            if not tests:
+                continue
+            common = baseline_set.intersection(tests.keys())
+            if not common:
+                continue
+            values = [tests[name] for name in common]
+            result.setdefault(version, {})[file_name] = sum(values) / len(values)
+    return result
+
+
+def _plot_deltas(
+    baseline: str, versions: list[str], series: dict[str, dict[str, float]]
+) -> Path:
+    files = sorted(series.get(baseline, {}).keys())
+    if not files:
+        raise RuntimeError("No benchmark data found to plot")
+
+    baseline_stats = series.get(baseline, {})
+    labels = files
+    x = range(len(labels))
+    width = 0.8 / max(len(versions), 1)
+
+    fig, ax = plt.subplots(figsize=(max(8, len(labels) * 0.6), 5))
+    offset = 0
+    for version in versions:
+        values = []
+        for file_name in labels:
+            base = baseline_stats.get(file_name)
+            cur = series.get(version, {}).get(file_name)
+            if base is None or cur is None:
+                values.append(float("nan"))
+            else:
+                values.append(cur / base)
+        positions = [i + offset for i in x]
+        ax.bar(positions, values, width=width, label=version)
+        offset += width
+
+    ax.axhline(1.0, color="black", linewidth=0.8)
+    ax.set_xticks([i + width * (len(versions) / 2) for i in x])
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+    ax.set_ylabel("Time relative to baseline (baseline = 1.0)")
+    ax.set_title(f"jsonpickle benchmark time ratios vs {baseline}")
+    ax.legend()
+    fig.tight_layout()
+
+    timestamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H%M%S%z")
+    output = IMAGES_DIR / f"benchmark-compare-{timestamp}.png"
+    fig.savefig(output)
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "versions",
+        help="Comma-delimited list of jsonpickle versions (e.g. 3.0.0,3.1.0)",
+    )
+    parser.add_argument(
+        "--output",
+        help="Output path for the comparison plot (PNG)",
+    )
+    args = parser.parse_args()
+
+    versions = [v.strip() for v in args.versions.split(",") if v.strip()]
+    if not versions:
+        print("Please provide at least one version!", file=sys.stderr)
+        return
+
+    (ROOT / ".bench-venvs").mkdir(exist_ok=True)
+    IMAGES_DIR.mkdir(exist_ok=True)
+    DATA_DIR.mkdir(exist_ok=True)
+
+    tags = _git_tags()
+    _run_benchmarks_local()
+    for version in versions:
+        tag = _resolve_tag(version, tags)
+        worktree = _ensure_worktree(tag)
+        python = _ensure_venv(version)
+        _run_benchmarks(version, python, worktree)
+
+    versions_all = ["local", *versions]
+    raw = {version: _load_benchmarks_for(version) for version in versions_all}
+    series = _compute_file_means("local", versions_all, raw)
+    output = _plot_deltas("local", versions_all, series)
+
+    if args.output:
+        target = Path(args.output)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(output.read_bytes())
+        print(f"Saved plot to {target}")
+    else:
+        print(f"Saved plot to {output}")
+    return
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarking/jsonpickle_pytest_benchmarks.py
+++ b/benchmarking/jsonpickle_pytest_benchmarks.py
@@ -8,6 +8,7 @@ JSONPICKLE_BENCH_JOBS to run several files concurrently.
 
 from __future__ import annotations
 
+import json
 import os
 import queue
 import re
@@ -25,7 +26,29 @@ _FILE_FLAG = "--jsonpickle-bench-file"
 _TIMESTAMP_FLAG = "--jsonpickle-bench-timestamp"
 
 
+def _item_key(item):
+    file_path = str(getattr(item, "path", "")) or item.nodeid.split("::", 1)[0]
+    return f"{Path(file_path).name}::{item.name}"
+
+
+class _CollectKeysPlugin:
+    def __init__(self):
+        self.keys = []
+
+    def pytest_collection_modifyitems(self, session, config, items):
+        self.keys.extend(_item_key(item) for item in items)
+
+
 class _BenchmarkAllTestsPlugin:
+    def __init__(self, allowed=None):
+        # for benchmark_versions we sometimes need to restrict the tests that run
+        self.allowed = allowed
+
+    def pytest_collection_modifyitems(self, session, config, items):
+        if self.allowed is None:
+            return
+        items[:] = [item for item in items if _item_key(item) in self.allowed]
+
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item):
         if not isinstance(item, pytest.Function):
@@ -262,8 +285,7 @@ def _split_args(argv):
     return single_file, timestamp, extra_args
 
 
-def _run_one_file(test_file, timestamp, extra_args):
-    file_label = test_file.name
+def _pytest_config_args():
     args = []
     pytest_config = os.environ.get("JSONPICKLE_PYTEST_CONFIG")
     pytest_rootdir = os.environ.get("JSONPICKLE_ROOTDIR")
@@ -271,12 +293,36 @@ def _run_one_file(test_file, timestamp, extra_args):
         args.extend(["-c", pytest_config])
     if pytest_rootdir:
         args.extend(["--rootdir", pytest_rootdir])
+    return args
+
+
+def _load_allowed():
+    only = os.environ.get("JSONPICKLE_BENCH_ONLY")
+    if not only:
+        return None
+    with open(only, encoding="utf-8") as handle:
+        return set(json.load(handle))
+
+
+def _collect_keys(test_files):
+    plugin = _CollectKeysPlugin()
+    for test_file in test_files:
+        args = _pytest_config_args()
+        args.append(str(test_file))
+        args.extend(["--collect-only", "-q", "-p", "no:cacheprovider"])
+        pytest.main(args, plugins=[plugin])
+    return sorted(set(plugin.keys))
+
+
+def _run_one_file(test_file, timestamp, extra_args):
+    file_label = test_file.name
+    args = _pytest_config_args()
     args.append(str(test_file))
     args.extend(_default_benchmark_args(timestamp, file_label, extra_args))
     if file_label == "jsonpickle_test.py":
         extra_args = [arg for arg in extra_args if arg != "--benchmark-disable-gc"]
     args.extend(extra_args)
-    return pytest.main(args, plugins=[_BenchmarkAllTestsPlugin()])
+    return pytest.main(args, plugins=[_BenchmarkAllTestsPlugin(_load_allowed())])
 
 
 def _run_serial(test_files, timestamp, extra_args):
@@ -341,6 +387,17 @@ def main():
         if not _verify_expected_version():
             return 2
         return _run_one_file(Path(single_file), timestamp, extra_args)
+
+    # collect-only mode, so benchmark_versions.py can work out which tests every
+    # version has in common before any of them are actually benchmarked
+    collect_target = os.environ.get("JSONPICKLE_BENCH_COLLECT")
+    if collect_target:
+        if not _verify_expected_version():
+            return 2
+        tests_dir = Path(os.environ.get("JSONPICKLE_TESTS_DIR", "tests")).resolve()
+        keys = _collect_keys(sorted(tests_dir.rglob("*.py")))
+        Path(collect_target).write_text(json.dumps(keys), encoding="utf-8")
+        return 0
 
     jobs = _resolve_jobs(os.environ.get("JSONPICKLE_BENCH_JOBS", 1))
     cores = _benchmark_cores(jobs) if jobs > 1 else []

--- a/benchmarking/jsonpickle_pytest_benchmarks.py
+++ b/benchmarking/jsonpickle_pytest_benchmarks.py
@@ -1,6 +1,5 @@
 """
 Run the Pytest test suite through pytest-benchmark.
-This benchmarks every collected test and produces one histogram per file.
 
 Files are benchmarked one at a time by default, but you can set
 JSONPICKLE_BENCH_JOBS to run several files concurrently.
@@ -9,6 +8,7 @@ JSONPICKLE_BENCH_JOBS to run several files concurrently.
 from __future__ import annotations
 
 import json
+import math
 import os
 import queue
 import re
@@ -81,14 +81,25 @@ def _sanitize_tag(value):
     return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
 
 
+def _tag_suffix():
+    tag = os.environ.get("JSONPICKLE_BENCH_TAG")
+    return f"-{_sanitize_tag(tag)}" if tag else ""
+
+
+def _images_dir():
+    output_root = os.environ.get("JSONPICKLE_BENCH_OUTPUT_ROOT", ".")
+    return Path(output_root) / "images"
+
+
+def _data_dir():
+    return _images_dir() / "benchmark-data"
+
+
 def _default_benchmark_args(timestamp, file_label, extra_args):
     existing = set(arg.split("=", 1)[0] for arg in extra_args)
     defaults = []
-    tag = os.environ.get("JSONPICKLE_BENCH_TAG")
-    tag_suffix = f"-{_sanitize_tag(tag)}" if tag else ""
-    output_root = os.environ.get("JSONPICKLE_BENCH_OUTPUT_ROOT", ".")
-    images_dir = Path(output_root) / "images"
-    data_dir = images_dir / "benchmark-data"
+    tag_suffix = _tag_suffix()
+    data_dir = _data_dir()
     if file_label != "jsonpickle_test.py" and "--benchmark-disable-gc" not in existing:
         defaults.append("--benchmark-disable-gc")
     if "--benchmark-warmup" not in existing:
@@ -97,11 +108,7 @@ def _default_benchmark_args(timestamp, file_label, extra_args):
         defaults.append("--benchmark-warmup-iterations=1")
     if "--benchmark-min-rounds" not in existing:
         defaults.append("--benchmark-min-rounds=10000")
-    if "--benchmark-histogram" not in existing:
-        images_dir.mkdir(parents=True, exist_ok=True)
-        defaults.append(
-            f"--benchmark-histogram={images_dir}/benchmark-{timestamp}-{file_label}{tag_suffix}"
-        )
+    # no per-file histogram, the run ends with one summary plot over every file
     if "--benchmark-storage" not in existing:
         data_dir.mkdir(parents=True, exist_ok=True)
         defaults.append(f"--benchmark-storage={data_dir}")
@@ -380,6 +387,144 @@ def _run_parallel(test_files, timestamp, extra_args, cores):
     return exit_code
 
 
+def geometric_mean(values):
+    """
+    Benchmark times are on the order of 1e-5 seconds, so multiplying a few
+    hundred of them together would flush to zero long before we took the root.
+    Therefore, we compute it in log-space.
+    """
+    return math.exp(math.fsum(math.log(value) for value in values) / len(values))
+
+
+def _load_run_means(timestamp):
+    """
+    Return {file_label: [mean seconds per test]} for the saved runs of this
+    invocation. pytest-benchmark writes one JSON file per --benchmark-save,
+    under a machine-id subdirectory of the storage dir.
+    """
+    data_dir = _data_dir()
+    if not data_dir.exists():
+        return {}
+    per_file = {}
+    for path in sorted(data_dir.rglob("*.json")):
+        # every save name for this run is "<timestamp>-<file label><tag suffix>"
+        if timestamp not in path.name:
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError):
+            print(f"Ignoring unreadable benchmark data at {path}", file=sys.stderr)
+            continue
+        # strip the "0001_" counter pytest-benchmark prepends, then the run tags
+        fallback = path.stem.split("_", 1)[-1].split(f"{timestamp}-", 1)[-1]
+        for bench in payload.get("benchmarks", []):
+            label = bench.get("group") or fallback
+            mean = bench.get("stats", {}).get("mean")
+            # log() needs strictly positive input, and a zero-length timing is
+            # junk data anyway, so drop those tests rather than crashing on them
+            if mean is None or mean <= 0:
+                continue
+            per_file.setdefault(label, []).append(mean)
+    return per_file
+
+
+def plot_file_summary(per_file, title, output):
+    """
+    Draw a single box and whisker plot for a whole run: one box per test file
+    over that file's per-test mean times (in seconds), marked with the
+    geometric mean of those means. Returns the written path, or None if
+    matplotlib is unavailable.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print(
+            "matplotlib is not installed, skipping the summary plot",
+            file=sys.stderr,
+        )
+        return None
+
+    # alphabetical, so the same file sits in the same spot across runs
+    labels = sorted(per_file)
+    # microseconds keep the tick labels readable for the fastest tests
+    data = [[mean * 1e6 for mean in per_file[name]] for name in labels]
+    geomeans = [geometric_mean(values) for values in data]
+
+    fig, ax = plt.subplots(figsize=(max(8, len(labels) * 0.7), 6))
+    ink = "#3b6fb0"
+    ax.boxplot(
+        data,
+        showfliers=True,
+        widths=0.55,
+        medianprops={"color": ink, "linewidth": 2},
+        boxprops={"color": "#5f6b7a", "linewidth": 1},
+        whiskerprops={"color": "#5f6b7a", "linewidth": 1},
+        capprops={"color": "#5f6b7a", "linewidth": 1},
+        flierprops={
+            "marker": "o",
+            "markersize": 3,
+            "markerfacecolor": "none",
+            "markeredgecolor": "#9aa4b1",
+        },
+    )
+    ax.plot(
+        range(1, len(labels) + 1),
+        geomeans,
+        linestyle="none",
+        marker="D",
+        markersize=8,
+        markerfacecolor=ink,
+        markeredgecolor="white",
+        label="geometric mean of per-test means",
+    )
+    # set the ticks by hand because boxplot renamed its label argument in 3.9
+    ax.set_xticks(range(1, len(labels) + 1))
+    ax.set_xticklabels(
+        [f"{name}\n({len(values)} tests)" for name, values in zip(labels, data)]
+    )
+    ax.set_yscale("log")
+    ax.set_ylabel("Mean time per test (microseconds, log scale)")
+    # the legend sits above the axes so that it can't cover a tall box
+    ax.set_title(title, pad=26)
+    ax.grid(axis="y", color="#d7dbe0", linewidth=0.6)
+    ax.set_axisbelow(True)
+    ax.legend(loc="lower left", bbox_to_anchor=(0, 1.005), frameon=False)
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
+    fig.tight_layout()
+
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=150)
+    plt.close(fig)
+    return output
+
+
+def print_file_summary(per_file, header="benchmark summary"):
+    print(f"\n===== {header} (geometric mean of per-test means) =====")
+    for name in sorted(per_file):
+        values = per_file[name]
+        print(f"{name}: {geometric_mean(values) * 1e6:.3f}us over {len(values)} tests")
+
+
+def _report_summary(timestamp):
+    per_file = _load_run_means(timestamp)
+    if not per_file:
+        print("No benchmark data was saved, skipping the summary plot")
+        return
+    print_file_summary(per_file)
+    output = plot_file_summary(
+        per_file,
+        f"jsonpickle test suite benchmark summary ({timestamp})",
+        _images_dir() / f"benchmark-summary-{timestamp}{_tag_suffix()}.png",
+    )
+    if output is not None:
+        print(f"Saved summary plot to {output}")
+
+
 def main():
     single_file, timestamp, extra_args = _split_args(sys.argv[1:])
 
@@ -416,9 +561,16 @@ def main():
     test_files = sorted(tests_dir.rglob("*.py"))
     timestamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H%M%S%z")
     if jobs <= 1:
-        return _run_serial(test_files, timestamp, extra_args)
-    print(f"Benchmarking {len(test_files)} files across cores {cores}")
-    return _run_parallel(test_files, timestamp, extra_args, cores)
+        exit_code = _run_serial(test_files, timestamp, extra_args)
+    else:
+        print(f"Benchmarking {len(test_files)} files across cores {cores}")
+        exit_code = _run_parallel(test_files, timestamp, extra_args, cores)
+
+    # benchmark_versions.py plots its own cross-version comparison, so a
+    # per-version summary plot there would just be noise
+    if not os.environ.get("JSONPICKLE_BENCH_ONLY"):
+        _report_summary(timestamp)
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/benchmarking/jsonpickle_pytest_benchmarks.py
+++ b/benchmarking/jsonpickle_pytest_benchmarks.py
@@ -96,7 +96,7 @@ def _data_dir():
 
 
 def _default_benchmark_args(timestamp, file_label, extra_args):
-    existing = set(arg.split("=", 1)[0] for arg in extra_args)
+    existing = {arg.split("=", 1)[0] for arg in extra_args}
     defaults = []
     tag_suffix = _tag_suffix()
     data_dir = _data_dir()
@@ -108,6 +108,9 @@ def _default_benchmark_args(timestamp, file_label, extra_args):
         defaults.append("--benchmark-warmup-iterations=1")
     if "--benchmark-min-rounds" not in existing:
         defaults.append("--benchmark-min-rounds=10000")
+    if "--benchmark-min-rounds" not in existing:
+        # no more than 10 seconds
+        defaults.append("--benchmark-max-time=10")
     # no per-file histogram, the run ends with one summary plot over every file
     if "--benchmark-storage" not in existing:
         data_dir.mkdir(parents=True, exist_ok=True)
@@ -233,7 +236,7 @@ def _verify_expected_version():
         return True
     try:
         import jsonpickle  # type: ignore
-    except Exception as exc:
+    except Exception as exc:  # ruff: ignore[BLE001]
         print(f"Failed to import jsonpickle: {exc}", file=sys.stderr)
         return False
 
@@ -369,7 +372,7 @@ def _run_parallel(test_files, timestamp, extra_args, cores):
             )
             env = os.environ.copy()
             env["JSONPICKLE_TASKSET"] = "1"
-            result = run(command, env=env, capture_output=True, text=True)
+            result = run(command, env=env, capture_output=True, text=True, check=False)
         finally:
             available.put(core)
         with print_lock:
@@ -544,7 +547,7 @@ def main():
         Path(collect_target).write_text(json.dumps(keys), encoding="utf-8")
         return 0
 
-    jobs = _resolve_jobs(os.environ.get("JSONPICKLE_BENCH_JOBS", 1))
+    jobs = _resolve_jobs(int(os.environ.get("JSONPICKLE_BENCH_JOBS", "1")))
     cores = _benchmark_cores(jobs) if jobs > 1 else []
     if jobs > 1 and len(cores) < jobs:
         print(

--- a/benchmarking/jsonpickle_pytest_benchmarks.py
+++ b/benchmarking/jsonpickle_pytest_benchmarks.py
@@ -436,12 +436,8 @@ def geometric_mean(values):
 
 def _load_run_means(timestamp):
     """
-    Return ({file_label: [mean seconds per test]}, unconverged) for the saved runs of
-    this invocation. pytest-benchmark writes one JSON file per --benchmark-save, under a
-    machine-id subdirectory of the storage dir.
-
-    ``unconverged`` lists the tests whose mean never reached --benchmark-precision, since
-    those are the points on the plot that the next run is least likely to reproduce.
+    Since pytest-benchmark writes one JSON file for every --benchmark-save, we have to load
+    the means of that data off disk into a list.
     """
     data_dir = _data_dir()
     if not data_dir.exists():
@@ -456,7 +452,10 @@ def _load_run_means(timestamp):
             with path.open("r", encoding="utf-8") as handle:
                 payload = json.load(handle)
         except (OSError, ValueError):
-            print(f"Ignoring unreadable benchmark data at {path}", file=sys.stderr)
+            print(
+                f"WARNING: Ignoring unreadable benchmark data at {path}",
+                file=sys.stderr,
+            )
             continue
         # strip the "0001_" counter pytest-benchmark prepends, then the run tags
         fallback = path.stem.split("_", 1)[-1].split(f"{timestamp}-", 1)[-1]

--- a/benchmarking/jsonpickle_pytest_benchmarks.py
+++ b/benchmarking/jsonpickle_pytest_benchmarks.py
@@ -1,0 +1,368 @@
+"""
+Run the Pytest test suite through pytest-benchmark.
+This benchmarks every collected test and produces one histogram per file.
+
+Files are benchmarked one at a time by default, but you can set
+JSONPICKLE_BENCH_JOBS to run several files concurrently.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from subprocess import run
+from threading import Lock
+
+import pytest
+
+# internal flags we hand to the per-file workers
+_FILE_FLAG = "--jsonpickle-bench-file"
+_TIMESTAMP_FLAG = "--jsonpickle-bench-timestamp"
+
+
+class _BenchmarkAllTestsPlugin:
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
+        if not isinstance(item, pytest.Function):
+            yield
+            return
+        if "benchmark" in item.fixturenames:
+            # this is for the case of the legacy jsonpickle_benchmarks.py file
+            yield
+            return
+
+        file_path = str(getattr(item, "path", "")) or item.nodeid.split("::", 1)[0]
+        file_label = Path(file_path).name
+
+        original_runtest = item.runtest
+
+        def benchmarked_runtest():
+            benchmark = item._request.getfixturevalue("benchmark")
+            if hasattr(benchmark, "group"):
+                benchmark.group = file_label
+            benchmark(original_runtest)
+
+        item.runtest = benchmarked_runtest
+        try:
+            yield
+        finally:
+            item.runtest = original_runtest
+
+
+def _sanitize_tag(value):
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
+
+
+def _default_benchmark_args(timestamp, file_label, extra_args):
+    existing = set(arg.split("=", 1)[0] for arg in extra_args)
+    defaults = []
+    tag = os.environ.get("JSONPICKLE_BENCH_TAG")
+    tag_suffix = f"-{_sanitize_tag(tag)}" if tag else ""
+    output_root = os.environ.get("JSONPICKLE_BENCH_OUTPUT_ROOT", ".")
+    images_dir = Path(output_root) / "images"
+    data_dir = images_dir / "benchmark-data"
+    if file_label != "jsonpickle_test.py" and "--benchmark-disable-gc" not in existing:
+        defaults.append("--benchmark-disable-gc")
+    if "--benchmark-warmup" not in existing:
+        defaults.append("--benchmark-warmup=on")
+    if "--benchmark-warmup-iterations" not in existing:
+        defaults.append("--benchmark-warmup-iterations=1")
+    if "--benchmark-min-rounds" not in existing:
+        defaults.append("--benchmark-min-rounds=10000")
+    if "--benchmark-histogram" not in existing:
+        images_dir.mkdir(parents=True, exist_ok=True)
+        defaults.append(
+            f"--benchmark-histogram={images_dir}/benchmark-{timestamp}-{file_label}{tag_suffix}"
+        )
+    if "--benchmark-storage" not in existing:
+        data_dir.mkdir(parents=True, exist_ok=True)
+        defaults.append(f"--benchmark-storage={data_dir}")
+    if "--benchmark-save" not in existing:
+        defaults.append(f"--benchmark-save={timestamp}-{file_label}{tag_suffix}")
+    return defaults
+
+
+def _taskset_pin_if_available():
+    # match logic from the make benchmark command
+    if os.environ.get("JSONPICKLE_TASKSET", "") == "1":
+        return
+    if sys.platform != "linux":
+        return
+    taskset = "taskset"
+    if not _which(taskset):
+        return
+    cpu_count = os.cpu_count() or 1
+    if cpu_count > 16:
+        target_core = 7
+    else:
+        target_core = max(cpu_count // 2 - 1, 0)
+    os.environ["JSONPICKLE_TASKSET"] = "1"
+    script = str(Path(__file__).resolve())
+    os.execvp(
+        taskset,
+        [taskset, "-c", str(target_core), sys.executable, script, *sys.argv[1:]],
+    )
+
+
+def _parse_cpu_list(raw):
+    # sysfs writes these as "0,8" on some kernels and "0-1" on others
+    values = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start, end = part.split("-", 1)
+            values.extend(range(int(start), int(end) + 1))
+        else:
+            values.append(int(part))
+    return values
+
+
+def _physical_cores():
+    """
+    In order to avoid pinning CPUs to SMT siblings, we only return
+    one logical CPU per physical core
+    """
+    seen = set()
+    cores = []
+    cpu_root = Path("/sys/devices/system/cpu")
+    try:
+        cpu_dirs = sorted(cpu_root.glob("cpu[0-9]*"), key=lambda p: int(p.name[3:]))
+    except OSError:
+        cpu_dirs = []
+    for cpu_dir in cpu_dirs:
+        try:
+            raw = (cpu_dir / "topology" / "thread_siblings_list").read_text(
+                encoding="utf-8"
+            )
+        except OSError:
+            continue
+        siblings = frozenset(_parse_cpu_list(raw.strip()))
+        if siblings in seen:
+            continue
+        seen.add(siblings)
+        cores.append(int(cpu_dir.name[3:]))
+    if not cores:
+        # we can't find any sysfs topology so we're probably not on linux
+        # therefore we can just assume SMT and take every other logical CPU
+        cores = list(range(0, os.cpu_count() or 1, 2))
+    return cores
+
+
+def _resolve_jobs(requested):
+    # never use more than half of the machine's cores to avoid SMT issues
+    limit = max((os.cpu_count() or 2) // 2, 1)
+    try:
+        jobs = int(requested)
+    except (TypeError, ValueError):
+        print(f"Ignoring non-numeric job count {requested!r}", file=sys.stderr)
+        return 1
+    if jobs < 1:
+        return 1
+    if jobs > limit:
+        print(
+            f"You requested {jobs} jobs but more than {limit} will produce "
+            f"unreliable measurements so this will use {limit}!",
+            file=sys.stderr,
+        )
+        return limit
+    return jobs
+
+
+def _benchmark_cores(jobs):
+    """
+    Cores 0 and 1 handle the kernel's interrupt load and the last core
+    handles a bunch of other kernel tasks, so we start from the middle of the
+    list and walk outward.
+    """
+    cores = _physical_cores()
+    if not cores:
+        return []
+    start = min(max(len(cores) // 2 - 1, 0), len(cores) - 1)
+    ordered = cores[start:] + cores[:start]
+    return ordered[:jobs]
+
+
+def _which(executable):
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(path) / executable
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def _verify_expected_version():
+    expected = os.environ.get("JSONPICKLE_EXPECT_VERSION")
+    if not expected:
+        return True
+    try:
+        import jsonpickle  # type: ignore
+    except Exception as exc:
+        print(f"Failed to import jsonpickle: {exc}", file=sys.stderr)
+        return False
+
+    actual = getattr(jsonpickle, "__version__", "unknown")
+    module_path = Path(getattr(jsonpickle, "__file__", "")).resolve()
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_pkg = (repo_root / "jsonpickle").resolve()
+    expect_path = os.environ.get("JSONPICKLE_EXPECT_PATH")
+    if expect_path:
+        expected_pkg = Path(expect_path).resolve()
+        if expected_pkg not in module_path.parents:
+            print(
+                f"Expected jsonpickle under {expected_pkg}, got {module_path}",
+                file=sys.stderr,
+            )
+            return False
+        # if the expected path matches, allow version mismatches for older tags
+        return True
+
+    if expected == "local":
+        if repo_pkg not in module_path.parents:
+            print(
+                f"Expected local jsonpickle under {repo_pkg}, got {module_path}",
+                file=sys.stderr,
+            )
+            return False
+        return True
+
+    if actual != expected:
+        print(
+            f"Expected jsonpickle {expected}, got {actual} ({module_path})",
+            file=sys.stderr,
+        )
+        return False
+    if repo_pkg in module_path.parents:
+        print(
+            f"Expected site-packages jsonpickle for {expected}, got local path {module_path}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _split_args(argv):
+    single_file = None
+    timestamp = None
+    extra_args = []
+    for arg in argv:
+        name, _, value = arg.partition("=")
+        if name == _FILE_FLAG:
+            single_file = value
+        elif name == _TIMESTAMP_FLAG:
+            timestamp = value
+        else:
+            extra_args.append(arg)
+    return single_file, timestamp, extra_args
+
+
+def _run_one_file(test_file, timestamp, extra_args):
+    file_label = test_file.name
+    args = []
+    pytest_config = os.environ.get("JSONPICKLE_PYTEST_CONFIG")
+    pytest_rootdir = os.environ.get("JSONPICKLE_ROOTDIR")
+    if pytest_config:
+        args.extend(["-c", pytest_config])
+    if pytest_rootdir:
+        args.extend(["--rootdir", pytest_rootdir])
+    args.append(str(test_file))
+    args.extend(_default_benchmark_args(timestamp, file_label, extra_args))
+    if file_label == "jsonpickle_test.py":
+        extra_args = [arg for arg in extra_args if arg != "--benchmark-disable-gc"]
+    args.extend(extra_args)
+    return pytest.main(args, plugins=[_BenchmarkAllTestsPlugin()])
+
+
+def _run_serial(test_files, timestamp, extra_args):
+    # report the last failure we saw, so a bad file can fail the whole run
+    exit_code = 0
+    for test_file in test_files:
+        code = _run_one_file(test_file, timestamp, extra_args)
+        if code != 0:
+            exit_code = code
+    return exit_code
+
+
+def _run_parallel(test_files, timestamp, extra_args, cores):
+    script = str(Path(__file__).resolve())
+    available = queue.Queue()
+    for core in cores:
+        available.put(core)
+    print_lock = Lock()
+
+    # we run the longest file first so that a slow one isn't the last one left
+    ordered = sorted(test_files, key=lambda p: p.stat().st_size, reverse=True)
+
+    def run_one(test_file):
+        core = available.get()
+        try:
+            command = []
+            if _which("taskset"):
+                command.extend(["taskset", "-c", str(core)])
+            command.extend(
+                [
+                    sys.executable,
+                    script,
+                    f"{_FILE_FLAG}={test_file}",
+                    f"{_TIMESTAMP_FLAG}={timestamp}",
+                    *extra_args,
+                ]
+            )
+            env = os.environ.copy()
+            env["JSONPICKLE_TASKSET"] = "1"
+            result = run(command, env=env, capture_output=True, text=True)
+        finally:
+            available.put(core)
+        with print_lock:
+            print(f"===== {test_file.name} (core {core}) =====")
+            sys.stdout.write(result.stdout)
+            sys.stderr.write(result.stderr)
+            sys.stdout.flush()
+        return result.returncode
+
+    exit_code = 0
+    with ThreadPoolExecutor(max_workers=len(cores)) as pool:
+        for code in pool.map(run_one, ordered):
+            if code != 0:
+                exit_code = code
+    return exit_code
+
+
+def main():
+    single_file, timestamp, extra_args = _split_args(sys.argv[1:])
+
+    if single_file:
+        if not _verify_expected_version():
+            return 2
+        return _run_one_file(Path(single_file), timestamp, extra_args)
+
+    jobs = _resolve_jobs(os.environ.get("JSONPICKLE_BENCH_JOBS", 1))
+    cores = _benchmark_cores(jobs) if jobs > 1 else []
+    if jobs > 1 and len(cores) < jobs:
+        print(
+            f"Only found {len(cores)} usable physical core(s); using {len(cores)} job(s)",
+            file=sys.stderr,
+        )
+        jobs = len(cores)
+    if jobs <= 1:
+        _taskset_pin_if_available()
+    if not _verify_expected_version():
+        return 2
+
+    tests_dir = Path(os.environ.get("JSONPICKLE_TESTS_DIR", "tests")).resolve()
+    test_files = sorted(tests_dir.rglob("*.py"))
+    timestamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H%M%S%z")
+    if jobs <= 1:
+        return _run_serial(test_files, timestamp, extra_args)
+    print(f"Benchmarking {len(test_files)} files across cores {cores}")
+    return _run_parallel(test_files, timestamp, extra_args, cores)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarking/jsonpickle_pytest_benchmarks.py
+++ b/benchmarking/jsonpickle_pytest_benchmarks.py
@@ -13,6 +13,7 @@ import os
 import queue
 import re
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
@@ -106,11 +107,15 @@ def _default_benchmark_args(timestamp, file_label, extra_args):
         defaults.append("--benchmark-warmup=on")
     if "--benchmark-warmup-iterations" not in existing:
         defaults.append("--benchmark-warmup-iterations=1")
+    if "--benchmark-precision" not in existing:
+        # ensure that it benchmarks until the estimated mean is within 2% of the true mean
+        defaults.append("--benchmark-precision=0.02")
+    if "--benchmark-confidence" not in existing:
+        # make the 2% thing be with at least 98% confidence
+        defaults.append("--benchmark-confidence=0.98")
     if "--benchmark-min-rounds" not in existing:
-        defaults.append("--benchmark-min-rounds=10000")
-    if "--benchmark-min-rounds" not in existing:
-        # no more than 10 seconds
-        defaults.append("--benchmark-max-time=10")
+        # no more than 5 seconds regardless of the precision/confidence we want
+        defaults.append("--benchmark-max-time=5")
     # no per-file histogram, the run ends with one summary plot over every file
     if "--benchmark-storage" not in existing:
         data_dir.mkdir(parents=True, exist_ok=True)
@@ -324,7 +329,37 @@ def _collect_keys(test_files):
     return sorted(set(plugin.keys))
 
 
+_warmed_up = False
+
+
+def _warm_up_cpu():
+    """
+    Spin before the first measurement so that the core is already at its working clock.
+
+    On my (Theelx's) laptop, a core that has been idle starts around 40% slower and
+    takes a few hundred milliseconds to ramp up, which is long enough to inflate the
+    first test files of a run.
+    """
+    global _warmed_up
+    if _warmed_up:
+        return
+    _warmed_up = True
+    try:
+        seconds = float(os.environ.get("JSONPICKLE_BENCH_WARMUP_SECONDS", "1.0"))
+    except ValueError:
+        seconds = 1.0
+    if seconds <= 0:
+        return
+    deadline = time.perf_counter() + seconds
+    total = 0
+    while time.perf_counter() < deadline:
+        for i in range(20000):
+            total += i * i
+    return total
+
+
 def _run_one_file(test_file, timestamp, extra_args):
+    _warm_up_cpu()
     file_label = test_file.name
     args = _pytest_config_args()
     args.append(str(test_file))
@@ -401,13 +436,17 @@ def geometric_mean(values):
 
 def _load_run_means(timestamp):
     """
-    Return {file_label: [mean seconds per test]} for the saved runs of this
-    invocation. pytest-benchmark writes one JSON file per --benchmark-save,
-    under a machine-id subdirectory of the storage dir.
+    Return ({file_label: [mean seconds per test]}, unconverged) for the saved runs of
+    this invocation. pytest-benchmark writes one JSON file per --benchmark-save, under a
+    machine-id subdirectory of the storage dir.
+
+    ``unconverged`` lists the tests whose mean never reached --benchmark-precision, since
+    those are the points on the plot that the next run is least likely to reproduce.
     """
     data_dir = _data_dir()
     if not data_dir.exists():
-        return {}
+        return {}, []
+    unconverged = []
     per_file = {}
     for path in sorted(data_dir.rglob("*.json")):
         # every save name for this run is "<timestamp>-<file label><tag suffix>"
@@ -429,7 +468,15 @@ def _load_run_means(timestamp):
             if mean is None or mean <= 0:
                 continue
             per_file.setdefault(label, []).append(mean)
-    return per_file
+            precision = bench.get("precision")
+            if precision and not precision.get("converged", True):
+                achieved = precision.get("achieved")
+                achieved = "unknown" if achieved is None else f"{achieved:.2%}"
+                unconverged.append(
+                    f"{label}::{bench.get('name')} (+-{achieved}, "
+                    f"wanted +-{precision.get('target', 0):.2%})"
+                )
+    return per_file, unconverged
 
 
 def plot_file_summary(per_file, title, output):
@@ -514,11 +561,20 @@ def print_file_summary(per_file, header="benchmark summary"):
 
 
 def _report_summary(timestamp):
-    per_file = _load_run_means(timestamp)
+    per_file, unconverged = _load_run_means(timestamp)
     if not per_file:
         print("No benchmark data was saved, skipping the summary plot")
         return
     print_file_summary(per_file)
+    if unconverged:
+        print(
+            f"\n{len(unconverged)} benchmark(s) never reached --benchmark-precision, so "
+            f"the means will move between runs."
+        )
+        for entry in unconverged[:10]:
+            print(f"   {entry}")
+        if len(unconverged) > 10:
+            print(f"   ... and {len(unconverged) - 10} more")
     output = plot_file_summary(
         per_file,
         f"jsonpickle test suite benchmark summary ({timestamp})",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,9 @@ dev = [
 testing = [
     # core
     "pytest >= 6.0, != 8.1.*",
-    # temporarily pin to adaptive rounds branch until it's merged into main
-    # credit to @akx for implementing this!
-    "pytest-benchmark @ git+https://github.com/Theelx/pytest-benchmark.git",
+    # until the adaptive benchmarking changes are merged,
+    # use dependency groups
+    # "pytest-benchmark",
     "pytest-benchmark[histogram]",
     "pytest-checkdocs >= 1.2.3",
     "pytest-enabler >= 1.0.1",
@@ -85,6 +85,14 @@ packaging = [
     "setuptools_scm[toml]>=6.0",
     "twine",
     "pypi-attestations",
+]
+
+[dependency-groups]
+benchmark = [
+    # temporarily pin to adaptive rounds branch until it's merged into main
+    # credit to @akx for implementing this!
+    # install with "pip install jsonpickle[testing] --group benchmark"
+    "pytest-benchmark[histogram] @ git+https://github.com/Theelx/pytest-benchmark.git",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ dev = [
 testing = [
     # core
     "pytest >= 6.0, != 8.1.*",
-    "pytest-benchmark",
+    # temporarily pin to adaptive rounds branch until it's merged into main
+    # credit to @akx for implementing this!
+    "pytest-benchmark @ git+https://github.com/Theelx/pytest-benchmark.git",
     "pytest-benchmark[histogram]",
     "pytest-checkdocs >= 1.2.3",
     "pytest-enabler >= 1.0.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 .[dev,docs,testing]
+. --group benchmark


### PR DESCRIPTION
Thank you for contributing to jsonpickle! This is just a quick template for you to fill out to make sure that jsonpickle can stay insulated from any legal uncertainty regarding copyrightability of code made by generative AI, and to make sure that we keep the code base easily maintainable. 

In order for us to merge your PR, please confirm that all of these boxes are true when applied to this PR and check them if so. If any box is not applicable to your PR (e.g. if you made a documentation-only change), you should just check it instead of deleting it or leaving it un-checked.

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
   - [x] In the CHANGES.rst update, I added a link to the PR number that this will be (e.g. ``(+611)``) and (if applicable) added a link to the issue that this fixes (e.g. ``(#608)``).
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``ruff format``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guidelines:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer of every commit where AI is used containing the name of all generative AI models used for that commit.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.
   - [x] **I understand that if I used AI and the above checkmarks are not all true when I submit this PR, my PR will be closed.**
- [x] **I understand that if this checklist is deleted from the PR body, my PR will be closed.**
---

I've had it in my TODO list for a long time now to update the benchmarking system to make it more representative. Before this, the benchmarking system has done a good job of covering common cases and data structures, but it was limited when testing more complex situations and usage of various options in jsonpickle. This PR fixes that by hooking into pytest to use its test collection and running machinery to run benchmarks across the entire testing suite (all nearly 500 tests!). That way I don't have to duplicate code from tests if I want to reuse it for benchmarks, and it will automatically get more coverage as new tests are added.

I also added a script to benchmark various versions of jsonpickle for getting good comparison plots to visualize performance differences across versions. It currently only benchmarks all the tests that exist across all the tested versions in order to get a fair comparison, so if you don't bother testing super old versions then you'll get a more representative look since there are more tests nowadays. It also uses the geometric mean for each file so that longer tests don't skew the average like they would in an arithmetic mean.

This PR doesn't actually regenerate the current benchmarking graphs as there's no point in wasting that work until we know that this code is actually good. Once this is good enough to be merged, I'll make a followup PR that actually regenerates the graphs.

I've been working on this on and off for a few months now and it's finally ready, so I'm excited to hear what you think! While I know this is a big PR, it's also an important one so I'd appreciate a bit more than a quick skim. If you need to split up reviews across a few sessions, then that's totally fine!
