### PR TITLE
Fix __getstate__() returning an empty dict being ignored by the pickler

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -722,7 +722,7 @@ class Pickler:
             else:
                 if exclude and isinstance(state, dict):
                     state = {k: v for k, v in util.items(state, exclude=exclude)}
-                if state:
+                if state is not None:
                     return self._getstate(state, data)
 
         if isinstance(obj, types.ModuleType):

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -677,6 +677,33 @@ def test_supports_getstate_setstate(pickler, unpickler):
     assert obj == inflated
 
 
+def test_getstate_empty_dict_is_not_dropped(pickler, unpickler):
+    """__getstate__() returning an empty dict must still be honored (issue #454)
+
+    A falsy state (an empty dict) was previously treated the same as "no
+    custom state", so the pickler fell through and flattened obj.__dict__
+    directly instead -- silently bypassing any filtering __getstate__() had
+    performed (e.g. excluding unpicklable attributes).
+    """
+
+    class ExcludesEverything:
+        def __init__(self):
+            self.unpicklable = object()
+
+        def __getstate__(self):
+            return {}
+
+        def __setstate__(self, state):
+            pass
+
+    obj = ExcludesEverything()
+    flattened = pickler.flatten(obj)
+    assert flattened[tags.STATE] == {}
+    assert "unpicklable" not in flattened
+    inflated = unpickler.restore(flattened)
+    assert not hasattr(inflated, "unpicklable")
+
+
 def test_references(pickler, unpickler):
     """References in lists can roundtrip"""
     obj_a = Thing("foo")


### PR DESCRIPTION
Fixes #454.

## Problem

`Pickler._flatten_obj_instance()` handles objects with a custom `__getstate__()` via:

```python
if has_own_getstate:
    try:
        state = obj.__getstate__()
    except TypeError:
        ...
    else:
        if exclude and isinstance(state, dict):
            state = {k: v for k, v in util.items(state, exclude=exclude)}
        if state:
            return self._getstate(state, data)
```

`if state:` treats an empty dict the same as "no custom state was returned". When a `__getstate__()` implementation legitimately returns `{}` (for example, after filtering out every attribute via an exclude list, as in the linked issue), execution falls through past this block and the object is instead flattened via the `has_dict` branch further down, which flattens `obj.__dict__` directly. That silently discards whatever `__getstate__()` did -- attributes the caller explicitly excluded from serialization (including ones that may not be picklable) get serialized anyway.

## Fix

Check `state is not None` instead of the truthiness of `state`, so an empty-but-valid state dict is passed to `self._getstate()` (which produces `py/state: {}`) rather than being treated as absent.

## Testing

Added `test_getstate_empty_dict_is_not_dropped`, which defines a class whose `__getstate__()` returns `{}` while `__dict__` still holds an "unpicklable" attribute:
- Before the fix: the attribute leaks into the flattened output (`unpicklable` key present, no `py/state` key at all) -- reproducing the exact behavior from #454.
- After the fix: flattened output is `{"py/object": ..., "py/state": {}}`, the excluded attribute is absent, and decode round-trips correctly.

Ran the full existing test suite (`pytest tests/`, 422 passed, no regressions) plus `tests/jsonpickle_test.py` specifically (206 passed, was 205 before this PR's new test was added).
