### PR TITLE
Call __setstate__() for objects that implement it without a custom __getstate__()

### DIFF
--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -622,6 +622,13 @@ class Pickler:
         # not using has_method since __getstate__() is handled separately below
         # Note: on Python 3.11+, all objects have __getstate__.
 
+        # Objects that implement __setstate__() but not __getstate__() still
+        # need their state routed through the py/state path so that
+        # __setstate__() gets invoked on the way back in (matching the
+        # standard pickle protocol, where the default __getstate__() is
+        # just __dict__). See GH #307.
+        has_own_setstate = util.has_method(obj, "__setstate__")
+
         if has_class:
             cls = obj.__class__
         else:
@@ -711,9 +718,9 @@ class Pickler:
             if has_getinitargs:
                 data[tags.INITARGS] = self._flatten(obj.__getinitargs__())
 
-        if has_own_getstate:
+        if has_own_getstate or (has_own_setstate and has_dict):
             try:
-                state = obj.__getstate__()
+                state = obj.__getstate__() if has_own_getstate else obj.__dict__
             except TypeError:
                 # Has getstate but it cannot be called, e.g. file descriptors
                 # in Python3

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -1474,6 +1474,22 @@ class PickleProtocol2GetSetState(PickleProtocol2GetState):
             self.magic = False
 
 
+class SetStateOnlyThing:
+    """An object with __setstate__() but no custom __getstate__().
+
+    Regression fixture for GH #307: __setstate__() must still be called
+    on decode even when the class relies on the default state (its own
+    __dict__) rather than defining a custom __getstate__().
+    """
+
+    def __init__(self):
+        self.var = 55
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.setstate_was_called = True
+
+
 class PickleProtocol2ChildThing:
     """Provides ``__getnewargs__`` for pickle protocol v2"""
 
@@ -1982,6 +1998,24 @@ def test_setstate():
     encoded = jsonpickle.encode(instance)
     decoded = jsonpickle.decode(encoded)
     assert decoded.magic
+
+
+def test_setstate_called_without_custom_getstate():
+    """__setstate__() must be called even without a custom __getstate__
+
+    Previously, the pickler only wrapped state in "py/state" (which the
+    unpickler uses to decide whether to call __setstate__()) when the
+    class also defined a custom __getstate__(). A class that implements
+    only __setstate__() -- relying on the default state, i.e. its own
+    __dict__ -- was flattened as a plain object instead, and its
+    __setstate__() was silently never invoked on decode. See GH #307.
+    """
+    instance = SetStateOnlyThing()
+    encoded = jsonpickle.encode(instance)
+    assert tags.STATE in encoded
+    decoded = jsonpickle.decode(encoded)
+    assert decoded.setstate_was_called is True
+    assert decoded.var == 55
 
 
 def test_handles_nested_objects():


### PR DESCRIPTION
Fixes #307.

## Problem

The documentation says:

> Upon unpickling, if the class also defines the method `__setstate__()`, it is called with the unpickled state.

But `Pickler._flatten_obj_instance()` only routes an object through the `"py/state"` path (which `Unpickler._restore_state()` checks before calling `instance.__setstate__()`) when the class also defines a *custom* `__getstate__()`:

```python
has_own_getstate = hasattr(type(obj), "__getstate__") and type(
    obj
).__getstate__ is not getattr(object, "__getstate__", None)
...
if has_own_getstate:
    ...
    if state:
        return self._getstate(state, data)
```

A class that implements only `__setstate__()` -- relying on the default state (its own `__dict__`), exactly as the standard `pickle` protocol does -- never takes this branch. It falls through to the plain `has_dict` path instead, so the encoded JSON has no `"py/state"` wrapper, and `Unpickler._restore_state()` (the only place that calls `__setstate__()`) is never reached:

```pycon
>>> class Foo:
...     def __init__(self):
...         self.var = 55
...     def __setstate__(self, state):
...         self.__dict__.update(state)
...         self.setstate_was_called = True
>>> jsonpickle.encode(Foo())
'{"py/object": "__main__.Foo", "var": 55}'   # no py/state wrapper
>>> jsonpickle.decode(_).setstate_was_called  # AttributeError -- never set
```

This reproduces exactly as reported on current `main`.

## Fix

Treat a class with its own `__setstate__()` the same as one with a custom `__getstate__()`: route its state through `py/state`, using `obj.__dict__` as the state when there's no custom `__getstate__()` to call.

```python
has_own_setstate = util.has_method(obj, "__setstate__")
...
if has_own_getstate or (has_own_setstate and has_dict):
    try:
        state = obj.__getstate__() if has_own_getstate else obj.__dict__
    ...
```

## Testing

Added `test_setstate_called_without_custom_getstate` (plus a `SetStateOnlyThing` fixture class mirroring the existing `PickleProtocol2Get(Set)State` fixtures), reproducing the exact scenario from the issue: a class with `__setstate__()` but no `__getstate__()`. Asserts the encoded output contains `"py/state"` and that `__setstate__()` is actually invoked on decode.

- Without the fix: fails (`setstate_was_called` is never set).
- With the fix: passes.

Ran the full test suite (`pytest tests/ --ignore=tests/test_exceptions.py --ignore=tests/test_jsonschema_test_suite.py`, the two ignored files having pre-existing, unrelated missing-dependency collection errors in this environment): 422 passed, no regressions.

Note: this touches the same `has_own_getstate` branch in `pickler.py` as my other open PR (#621), which separately fixes a distinct bug where `__getstate__()` returning an empty dict is mishandled. The two changes don't conflict, but flagging the overlap for reviewer awareness.
