### PR TITLE
Reject ambiguous py/function resolutions during decode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ v5.0.0
       roundtrip. Generalizes the nanosecond fix from (#555). (+619)
     * The ability to run benchmarks over the entire pytest suite has been added
       in order to cover a wider portion of the codebase with the benchmarks. (+620)
+    * Decoding a ``py/function`` tag whose name resolves to an existing
+      non-function binding now raises ``TypeError`` instead of returning
+      the object unchanged. (#467) (+623)
 
 v4.1.2
 ======

--- a/jsonpickle/unpickler.py
+++ b/jsonpickle/unpickler.py
@@ -5,6 +5,7 @@
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution.
 import dataclasses
+import inspect
 import warnings
 from collections.abc import Callable, Iterator, Sequence
 from typing import Any, TypeAlias
@@ -891,7 +892,13 @@ class Unpickler:
         return self._restore_object_instance(obj, cls, class_name)
 
     def _restore_function(self, obj: dict[str, Any]) -> Any:
-        return util.loadclass(obj[tags.FUNCTION], classes=self._classes)
+        class_name = obj[tags.FUNCTION]
+        result = util.loadclass(class_name, classes=self._classes)
+        if inspect.isroutine(result) or inspect.isclass(result) or result is None:
+            return result
+        raise TypeError(
+            f"{class_name!r} resolves to a {type(result).__qualname__}, not a function"
+        )
 
     def _restore_set(self, obj: dict[str, Any]) -> set[Any]:
         try:

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -42,6 +42,24 @@ class Thing:
         return 'Thing("%s")' % self.name  # ruff: ignore[UP031]
 
 
+class AmbiguousDecorator:
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
+def _ambiguous_factory(func):
+    return AmbiguousDecorator(func)
+
+
+# ambiguous_target is bound to the wrapper instance, shadowing the function
+@_ambiguous_factory
+def ambiguous_target():
+    return "Mate"
+
+
 class Capture:
     def __init__(self, *args, **kwargs):
         self.args = args
@@ -728,6 +746,20 @@ def test_builtin_function():
     actual = jsonpickle.decode(json)
     assert expect == actual
     assert expect is actual
+
+
+def test_ambiguous_function_reference_regression_issue467():
+    assert type(ambiguous_target.func).__name__ == "function"
+    encoded = jsonpickle.encode(ambiguous_target)
+    # the payload must come from encode(); hand-built wire tags get stripped
+    assert tags.FUNCTION in encoded
+    with pytest.raises(TypeError):
+        jsonpickle.decode(encoded)
+
+
+def test_function_reference_resolution_contract():
+    assert jsonpickle.decode('{"py/function": "builtins.dir"}') is dir
+    assert jsonpickle.decode('{"py/function": "no.such.module.attr"}') is None
 
 
 def test_restore_legacy_builtins():


### PR DESCRIPTION
Thank you for contributing to jsonpickle! This is just a quick template for you to fill out to make sure that jsonpickle can stay insulated from any legal uncertainty regarding copyrightability of code made by generative AI, and to make sure that we keep the code base easily maintainable.

In order for us to merge your PR, please confirm that all of these boxes are true when applied to this PR and check them if so. If any box is not applicable to your PR (e.g. if you made a documentation-only change), you should just check it instead of deleting it or leaving it un-checked.

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
   - [x] In the CHANGES.rst update, I added a link to the PR number that this will be (e.g. ``(+611)``) and (if applicable) added a link to the issue that this fixes (e.g. ``(#608)``).
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``ruff format``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guidelines:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer of every commit where AI is used containing the name of all generative AI models used for that commit.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.
   - [x] **I understand that if I used AI and the above checkmarks are not all true when I submit this PR, my PR will be closed.**
- [x] **I understand that if this checklist is deleted from the PR body, my PR will be closed.**
---

Decoding a ``py/function`` tag whose name is shadowed by a non-function binding (e.g. a decorated function whose name now points at its own wrapper) silently returns that object ([#467](https://github.com/jsonpickle/jsonpickle/issues/467)).

``_restore_function`` accepted anything ``util.loadclass()`` resolved. It now only returns functions, classes, or ``None`` (the existing miss semantics); anything else raises ``TypeError``, so ambiguous references fail loudly instead of decoding into a wrong-typed object.

Tests: added a regression test for the wrapper-shadowing case in #467, with the payload taken straight from ``encode()``. Full suite: 396 passed, 2 skipped; ``ruff check`` / ``ruff format --check`` clean.
