### PR TITLE
Warn instead of silently dropping dict keys that collide with reserved tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
 v5.0.0
 ======
+    * jsonpickle now warns instead of silently dropping a dict key that collides
+      with a reserved tag (e.g. ``"py/object"``) when encoding with the default
+      ``keys=False``; use ``keys=True`` to preserve such keys. (+624)
     * **Breaking Change**: The ``yaml`` module is no longer registered by default.
       You can re-enable yaml support using ``jsonpickle.ext.yaml.register()``.
       (#550) (+551)

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -465,6 +465,18 @@ class Pickler:
         self, k: Any, v: Any, data: dict[str | Any, Any]
     ) -> dict[str | Any, Any]:
         """Flatten a key/value pair into the passed-in dictionary."""
+        if isinstance(k, str) and k in tags.RESERVED:
+            # A plain-string dict key that collides with a reserved jsonpickle
+            # wire tag (e.g. "py/object") cannot be represented in the default
+            # keys=False output -- it would be misread as that tag on decode --
+            # so it is dropped here. Warn instead of losing the value silently;
+            # encode(..., keys=True) escapes and preserves such keys.
+            warnings.warn(
+                f"jsonpickle: dropping dict key {k!r} that collides with a "
+                "reserved tag; use keys=True to preserve it",
+                stacklevel=2,
+            )
+            return data
         if not util._is_picklable(k, v):
             return data
         # TODO: use inspect.getmembers_static on 3.11+ because it avoids dynamic

--- a/tests/jsonpickle_test.py
+++ b/tests/jsonpickle_test.py
@@ -435,6 +435,25 @@ def test_dict(pickler, unpickler):
     assert unpickler.restore(dict_b) == dict_b
 
 
+def test_dict_reserved_key_warns_when_dropped():
+    """A dict key colliding with a reserved tag is dropped loudly, not silently.
+
+    In the default keys=False mode such a key cannot be represented (it would be
+    misread as that tag on decode), so it is dropped -- but it now emits a
+    warning instead of losing the value silently. keys=True preserves it.
+    """
+    data = {tags.OBJECT: "hello", "normal": 1}
+    with pytest.warns(UserWarning, match="reserved tag"):
+        encoded = jsonpickle.encode(data)
+    # Behaviour is unchanged (the colliding key is still dropped), only louder.
+    assert jsonpickle.decode(encoded) == {"normal": 1}
+    # keys=True escapes and preserves the key, and must not warn.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        encoded_keys = jsonpickle.encode(data, keys=True)
+    assert jsonpickle.decode(encoded_keys, keys=True) == data
+
+
 def test_tuple(pickler, unpickler):
     """Validate the internal represntation for tuples"""
     # currently all collections are converted to lists


### PR DESCRIPTION
## Problem

In the default `keys=False` mode, a plain-string dict key equal to a reserved jsonpickle wire tag (e.g. `"py/object"`, `"py/id"`, `"py/tuple"`) is dropped by the pickler:

```pycon
>>> import jsonpickle
>>> jsonpickle.encode({"py/object": "hello", "normal": 1})
'{"normal": 1}'          # the "py/object" entry is gone
```

This is intentional in the sense that such a key cannot be represented in `keys=False` output — it would be misread as that tag on decode, and `keys=False` deliberately passes `json://`-prefixed keys through verbatim (see `test_dict`), so there is no room to escape it. But the value is currently lost **silently**, which is an easy footgun for anyone whose data happens to contain such keys (config blobs, API payloads, ML metadata, etc.).

## Change

Emit a `UserWarning` pointing at `keys=True` (which escapes and preserves these keys) instead of dropping the value with no indication. This is scoped precisely:

- Only fires for a **string** key that is exactly a reserved tag, and only on the `keys=False` path where the drop actually happens.
- The drop behaviour itself is unchanged, so `keys=True` and any non-colliding key are entirely unaffected.

```pycon
>>> jsonpickle.encode({"py/object": "hello"})
UserWarning: jsonpickle: dropping dict key 'py/object' that collides with a reserved tag; use keys=True to preserve it
>>> jsonpickle.decode(jsonpickle.encode({"py/object": "hi"}, keys=True), keys=True)
{'py/object': 'hi'}
```

## Tests

Added `test_dict_reserved_key_warns_when_dropped` (warns + still drops in `keys=False`; preserved and no warning with `keys=True`). Verified it fails before the change and passes after. Full `tests/jsonpickle_test.py` passes except a pre-existing `test_load_backend` failure unrelated to this change (missing optional JSON backend in my env).

Happy to adjust — e.g. if you would prefer to raise, or escape reserved keys in `keys=False` too, I can take it in that direction instead.