### PR TITLE
tests: make the decimal.Decimal assertions stricter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,7 @@ v5.0.0
       roundtrip. Generalizes the nanosecond fix from (#555). (+619)
     * The ability to run benchmarks over the entire pytest suite has been added
       in order to cover a wider portion of the codebase with the benchmarks. (+620)
+    * `decimal.Decimal` tests were extended. (+625)
 
 v4.1.2
 ======

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -395,10 +395,36 @@ def test_set_subclass_with_data(pickler, unpickler):
 
 
 def test_decimal(pickler, unpickler):
-    obj = decimal.Decimal("0.5")
-    flattened = pickler.flatten(obj)
-    inflated = unpickler.restore(flattened)
-    assert isinstance(inflated, decimal.Decimal)
+    # 2.1 cannot be represented as a floating point number.
+    expect = decimal.Decimal("2.1")
+    encoded = pickler.flatten(expect)
+    actual = unpickler.restore(encoded)
+    assert expect == actual
+    assert actual.as_tuple().digits == (2, 1)
+
+
+class PassthroughHandler:
+    def __init__(self, context):
+        self.context = context
+
+    def flatten(self, obj, data):
+        return obj
+
+
+def test_decimal_passthrough_handler():
+    """Arbitrary objects can pass-through the json encoder"""
+    obj = decimal.Decimal("2.1")
+
+    # jsonpickle's default representation serializes via __reduce__().
+    actual = jsonpickle.dumps(obj)
+    assert actual != "2.1"
+
+    # The passthrough encoder lets the stdlib json module convert the Decimal instance
+    # into a plain json number.
+    jsonpickle.handlers.register(decimal.Decimal, PassthroughHandler)
+    actual = jsonpickle.dumps(obj)
+    jsonpickle.handlers.unregister(decimal.Decimal)
+    assert actual == "2.1"
 
 
 def test_oldstyleclass(pickler, unpickler):


### PR DESCRIPTION
--- 
In order for us to merge your PR, please confirm that all of these boxes are true when applied to this PR and check them if so. If any box is not applicable to your PR (e.g. if you made a documentation-only change), you should just check it instead of deleting it or leaving it un-checked.

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
   - [x] In the CHANGES.rst update, I added a link to the PR number that this will be (e.g. ``(+611)``) and (if applicable) added a link to the issue that this fixes (e.g. ``(#608)``).
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``ruff format``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guidelines:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer of every commit where AI is used containing the name of all generative AI models used for that commit.
   - [x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.
   - [x] **I understand that if I used AI and the above checkmarks are not all true when I submit this PR, my PR will be closed.**
- [x] **I understand that if this checklist is deleted from the PR body, my PR will be closed.**
---

The `as_tuple()` check is slightly tautological alongside the `assert expect == actual` check, but including it ensures that the instance is viable and working as expected.

Demonstrate how to use a passthrough handler to let arbitrary objects
(including Decimal instances) to passthrough to the backend as-is.
    
Related-to: #591