### PR TITLE
Fix roundtrip of compiled bytes regex patterns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,11 @@ v5.0.0
       roundtrip. Generalizes the nanosecond fix from (#555). (+619)
     * The ability to run benchmarks over the entire pytest suite has been added
       in order to cover a wider portion of the codebase with the benchmarks. (+620)
+    * Fix bug where compiled ``bytes`` regex patterns (e.g. ``re.compile(b"...")``)
+      failed to roundtrip: encoding raised with the stdlib ``json`` backend and
+      silently degraded the pattern to text with ``simplejson``/``ujson``, so the
+      decoded object was a text pattern that could no longer match bytes input.
+      The pattern payload is now preserved as base64 and rebuilt as bytes.
 
 v4.1.2
 ======

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -240,13 +240,26 @@ DatetimeHandler.handles(datetime.time)
 class RegexHandler(BaseHandler):
     """Flatten _sre.SRE_Pattern (compiled regex) objects"""
 
-    def flatten(self, obj: re.Pattern[str], data: dict[str, Any]) -> HandlerReturn:
-        data["pattern"] = obj.pattern
+    def flatten(self, obj: re.Pattern[Any], data: dict[str, Any]) -> HandlerReturn:
+        pattern = obj.pattern
+        # A bytes pattern is not a JSON string. Storing it verbatim relies on
+        # the backend, which either raises (stdlib json) or silently coerces
+        # the bytes to text (simplejson/ujson), so that restore() rebuilds a
+        # text pattern instead of the original bytes pattern. Preserve the raw
+        # payload as base64 and remember that it was bytes.
+        if isinstance(pattern, bytes):
+            data["pattern"] = util.b64encode(pattern)
+            data["is_bytes"] = True
+        else:
+            data["pattern"] = pattern
         data["flags"] = obj.flags
         return data
 
-    def restore(self, data: dict[str, Any]) -> re.Pattern[str]:
-        return re.compile(data["pattern"], data.get("flags", 0))
+    def restore(self, data: dict[str, Any]) -> re.Pattern[Any]:
+        pattern = data["pattern"]
+        if data.get("is_bytes", False):
+            pattern = util.b64decode(pattern)
+        return re.compile(pattern, data.get("flags", 0))
 
 
 RegexHandler.handles(type(re.compile("")))

--- a/tests/object_test.py
+++ b/tests/object_test.py
@@ -549,6 +549,18 @@ def test_compiled_regex_flags_roundtrip(pickler, unpickler):
     assert rgx.flags == restored.flags
 
 
+def test_compiled_bytes_regex_roundtrip(pickler, unpickler):
+    # A bytes pattern must survive a full JSON encode/decode cycle: its
+    # payload is not a JSON string, so the handler has to preserve both the
+    # bytes and the pattern type rather than degrading it to a text pattern.
+    rgx = re.compile(rb"[a-z]+", re.IGNORECASE)
+    restored = jsonpickle.decode(jsonpickle.encode(rgx))
+    assert isinstance(restored.pattern, bytes)
+    assert rgx.pattern == restored.pattern
+    assert rgx.flags == restored.flags
+    assert restored.match(b"abc").group(0) == b"abc"
+
+
 def test_base_object_roundrip(pickler, unpickler):
     roundtrip = unpickler.restore(pickler.flatten(object()))
     assert type(roundtrip) is object


### PR DESCRIPTION

## Problem

Encoding and decoding a compiled `bytes` regex pattern does not roundtrip.

```python
import re, jsonpickle
p = re.compile(rb"[a-z]+", re.IGNORECASE)
d = jsonpickle.decode(jsonpickle.encode(p))
type(d.pattern)      # <class 'str'>  -- was <class 'bytes'>
d.match(b"abc")      # TypeError: cannot use a string pattern on a bytes-like object
```

With the default backend chain (`simplejson`/`ujson`) the bytes payload is
silently coerced to text, so the decoded object is a *text* pattern that no
longer matches bytes input. With the stdlib `json` backend encoding raises
`TypeError: Object of type bytes is not JSON serializable` outright.

## Root cause

`jsonpickle/handlers.py`, `RegexHandler.flatten` stored the raw pattern:

```python
data["pattern"] = obj.pattern
```

For a bytes pattern `obj.pattern` is `bytes`, which is not a JSON string. The
value is written verbatim into the flattened dict and handed to the JSON
backend, which either raises or coerces the bytes to text. `RegexHandler.restore`
then calls `re.compile(data["pattern"], ...)` on that text and produces a text
pattern, losing both the byte type and (because compiling a text pattern adds
`re.UNICODE` automatically) the original flags.

## Fix

`jsonpickle/handlers.py`: detect a bytes pattern in `flatten`, store its payload
as base64 with an `is_bytes` marker, and decode it back to bytes in `restore`.
Text patterns are unchanged, so old payloads (which have no `is_bytes` key)
continue to decode exactly as before.

## Test

`tests/object_test.py::test_compiled_bytes_regex_roundtrip` encodes and decodes
a `bytes` pattern through the full JSON pipeline and asserts the restored pattern
is still `bytes`, keeps its flags, and matches bytes input. It fails on the
current `main` (`AssertionError: assert isinstance('[a-z]+', bytes)`) and passes
with the fix. The existing `test_thing_with_compiled_regex` and
`test_compiled_regex_flags_roundtrip` still pass.
