### PR TITLE
Remove use decimal & make backend tests run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,16 @@ v5.0.0
     * **Breaking Change**: Removed the deprecated functions deprecated in 4.1.0 with commit
       59dda25. Additionally, ``util.is_sequence`` was removed due to having only one caller,
       ``util.is_sequence_subclass``. (+563)
+    * **Breaking Change**: Removed the ``use_decimal`` argument for ``encode()``. As a
+      replacement, you can register the passthrough handler instead with this code::
+
+          jsonpickle.handlers.register(
+              decimal.Decimal, PassthroughHandler, base=True
+          )
+          jsonpickle.set_decoder_options("simplejson", use_decimal=True)
+          jsonpickle.set_preferred_backend("simplejson")
+
+      (+628)
     * Mypy-compatible typing has been added to the entire jsonpickle public API! (#561) (+563) (+603)
     * Fixed bug with pickling subclasses of Exception with keyword-only args. (#564) (+565)
     * Removed jsonpickleJS from the tree. (#568) (+569)

--- a/jsonpickle/handlers.py
+++ b/jsonpickle/handlers.py
@@ -328,3 +328,38 @@ class TextIOHandler(BaseHandler):
 
 
 TextIOHandler.handles(io.TextIOWrapper)
+
+
+class PassthroughHandler(BaseHandler):
+    """
+    Hand objects to the backend untouched instead of flattening them.
+
+    Backends can support types that jsonpickle would otherwise flatten into a
+    py/object payload. simplejson in use_decimal mode, for example, writes
+    decimal.Decimal out as a plain json number. You will normally want to register
+    this using base=True.
+
+    This handler is not registered for any type by default. The backend must know
+    how to encode and decode the object, so ensure that it can before using this!
+
+    Example usage::
+
+        jsonpickle.handlers.register(
+            decimal.Decimal, PassthroughHandler, base=True
+        )
+
+    """
+
+    def flatten(self, obj: Any, data: dict[str, Any]) -> Any:
+        # the pickler logged a reference before dispatching here, but the
+        # backend writes obj as an opaque value that no py/id entry can
+        # point at. therefore, drop the reference so that a repeat of the
+        # same instance is encoded again instead of becoming a dangling reference
+        self.context._unlog_ref(obj)
+        return obj
+
+    def restore(self, data: dict[str, Any]) -> NoReturn:
+        """
+        Restore should never get called because flatten() returns obj
+        """
+        raise AssertionError("Restoring PassthroughHandler is not supported")

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -333,6 +333,15 @@ class Pickler:
         pretend_new = not self.unpicklable or not self.make_refs
         return pretend_new or is_new
 
+    def _unlog_ref(self, obj: Any) -> None:
+        """
+        Undo the most recent _log_ref(), making obj unreferenceable.
+        This was added to fix the bug described in
+        test_decimal_passthrough_repeated_instance. Only safe to call for
+        an object that was just logged, which basically limits it to handlers.
+        """
+        self._objs.pop(id(obj), None)
+
     def _getref(self, obj: Any) -> dict[str, int]:
         """Return a "py/id" entry for the specified object"""
         return {tags.ID: self._objs.get(id(obj))}  # type: ignore[dict-item]

--- a/jsonpickle/pickler.py
+++ b/jsonpickle/pickler.py
@@ -4,7 +4,6 @@
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution.
-import decimal
 import inspect
 import itertools
 import sys
@@ -29,7 +28,6 @@ def encode(
     warn: bool = False,
     context: "Pickler | None" = None,
     max_iter: int | None = None,
-    use_decimal: bool = False,
     numeric_keys: bool = False,
     use_base85: bool = False,
     fail_safe: Callable[[Exception], Any] | None = None,
@@ -86,19 +84,6 @@ def encode(
         invoked by jsonpickle.
     :param max_iter: If set to a non-negative integer then jsonpickle will
         consume at most `max_iter` items when pickling iterators.
-    :param use_decimal: If set to True jsonpickle will allow Decimal
-        instances to pass-through, with the assumption that the simplejson
-        backend will be used in `use_decimal` mode.  In order to use this mode
-        you will need to configure simplejson::
-
-            jsonpickle.set_encoder_options('simplejson',
-                                           use_decimal=True, sort_keys=True)
-            jsonpickle.set_decoder_options('simplejson',
-                                           use_decimal=True)
-            jsonpickle.set_preferred_backend('simplejson')
-
-        NOTE: A side-effect of the above settings is that float values will be
-        converted to Decimal when converting to json.
     :param numeric_keys: Only use this option if the backend supports integer
         dict keys natively.  This flag tells jsonpickle to leave numeric keys
         as-is rather than conforming them to json-friendly strings.
@@ -163,7 +148,6 @@ def encode(
         warn=warn,
         max_iter=max_iter,
         numeric_keys=numeric_keys,
-        use_decimal=use_decimal,
         use_base85=use_base85,
         fail_safe=fail_safe,
         include_properties=include_properties,
@@ -217,7 +201,6 @@ class Pickler:
         warn: bool = False,
         max_iter: int | None = None,
         numeric_keys: bool = False,
-        use_decimal: bool = False,
         use_base85: bool = False,
         fail_safe: Callable[[Exception], Any] | None = None,
         include_properties: bool = False,
@@ -242,8 +225,6 @@ class Pickler:
         self._seen = []
         # maximum amount of items to take from a pickled iterator
         self._max_iter = max_iter
-        # Whether to allow decimals to pass-through
-        self._use_decimal = use_decimal
         # A cache of objects that have already been flattened.
         self._flattened = {}
         # Used for util._is_readonly, see +483
@@ -402,10 +383,7 @@ class Pickler:
         if typeof_obj is bytes:
             return self._flatten_bytestring(obj)
 
-        # Decimal is a primitive when use_decimal is True
-        if typeof_obj in (str, bool, int, float, type(None)) or (
-            self._use_decimal and isinstance(obj, decimal.Decimal)
-        ):
+        if typeof_obj in (str, bool, int, float, type(None)):
             return obj
 
         # bytearray is list-like, so it is neither reducible nor atomic.

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,5 @@ filterwarnings=
     ignore:direct construction of .*Item has been deprecated:DeprecationWarning
 # add this so we dont have to put test_ before the benchmarks
 python_functions = test_* simple_* complex_* state_*
+# our test classes are named *TestCase, which pytest's default Test* misses
+python_classes = Test* *TestCase

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -29,6 +29,10 @@ class BSlots:
         self.a3 = self.a1  # create a reference
 
 
+class DecimalSubclass(decimal.Decimal):
+    pass
+
+
 SAMPLE_DATA = {"things": [Thing("data")]}
 
 
@@ -190,3 +194,141 @@ class YamlTestCase(BackendBase):
             "    child: null\n"
         )
         self.assert_roundtrip(expected_pickled)
+
+
+@pytest.fixture
+def simplejson_use_decimal():
+    """Serve Decimal via simplejson's use_decimal mode, then restore defaults"""
+    if not jsonpickle.util._is_installed("simplejson"):
+        pytest.skip("simplejson not available; please install")
+    jsonpickle.set_preferred_backend("simplejson")
+    jsonpickle.set_encoder_options("simplejson", use_decimal=True, sort_keys=True)
+    jsonpickle.set_decoder_options("simplejson", use_decimal=True)
+    try:
+        yield
+    finally:
+        jsonpickle.set_encoder_options("simplejson", use_decimal=False, sort_keys=False)
+        jsonpickle.set_decoder_options("simplejson", use_decimal=False)
+        jsonpickle.set_preferred_backend("json")
+
+
+@pytest.fixture
+def decimal_passthrough():
+    """
+    Register PassthroughHandler for Decimal and all of its subclasses
+    """
+    jsonpickle.handlers.register(
+        decimal.Decimal, jsonpickle.handlers.PassthroughHandler, base=True
+    )
+    try:
+        yield
+    finally:
+        jsonpickle.handlers.unregister(decimal.Decimal)
+
+
+def test_decimal_passthrough_handler(simplejson_use_decimal, decimal_passthrough):
+    """
+    Ensure that PassthroughHandler reproduces use_decimal=True without needing the
+    encode() flag that was removed in jsonpickle v5.
+    """
+    obj = decimal.Decimal("0.5")
+
+    assert jsonpickle.dumps(obj, unpicklable=True) == "0.5"
+    clone = jsonpickle.loads(jsonpickle.dumps(obj))
+    assert isinstance(clone, decimal.Decimal)
+    assert obj == clone
+
+    assert jsonpickle.dumps(DecimalSubclass("0.5")) == "0.5"
+
+    assert jsonpickle.dumps({"a": obj}) == '{"a": 0.5}'
+    assert jsonpickle.dumps({"a": {"b": [obj]}}) == '{"a": {"b": [0.5]}}'
+    assert jsonpickle.dumps([obj, decimal.Decimal("2.1")]) == "[0.5, 2.1]"
+
+    shared = decimal.Decimal("2.1")
+    values = [
+        decimal.Decimal("2.1"),
+        [decimal.Decimal("2.1"), decimal.Decimal("0.5")],
+        # ensure distinct instances of equal value are not deduplicated by either mode
+        [decimal.Decimal("2.1"), decimal.Decimal("2.1")],
+        # nor should the same instance be turned into a py/id reference
+        [shared, shared],
+        {"a": decimal.Decimal("2.1")},
+        {"a": {"b": [decimal.Decimal("2.1")]}},
+        {decimal.Decimal("2.1"): "a"},
+        DecimalSubclass("2.1"),
+    ]
+    for value in values:
+        with_handler = jsonpickle.dumps(value)
+        jsonpickle.handlers.unregister(decimal.Decimal)
+        try:
+            with_flag = jsonpickle.dumps(value, use_decimal=True)
+        finally:
+            jsonpickle.handlers.register(
+                decimal.Decimal, jsonpickle.handlers.PassthroughHandler, base=True
+            )
+        assert with_handler == with_flag, value
+
+
+def test_decimal_passthrough_repeated_instance(
+    simplejson_use_decimal, decimal_passthrough
+):
+    """
+    Make sure that the same Decimal instance repeats instead of becoming a py/id ref
+    when make_refs and/or unpickleable are set to False. This guards against a bug
+    encountered when drafting the passthrough handler, as it interacted with make_refs.
+
+    Bug: A handler is dispatched after _mkref() has already logged a reference, so
+    without the newly added _unlog_ref(), the second occurrence would encode as a py/id
+    entry, which is a reference the backend-level decode cannot resolve, which would give
+    us None instead of the original value.
+    """
+    shared = decimal.Decimal("2.1")
+
+    assert jsonpickle.dumps([shared, shared]) == "[2.1, 2.1]"
+    assert jsonpickle.loads(jsonpickle.dumps([shared, shared])) == [shared, shared]
+
+    for kwargs in ({"make_refs": False}, {"unpicklable": False}):
+        encoded = jsonpickle.dumps([shared, shared], **kwargs)
+        assert encoded == "[2.1, 2.1]"
+        assert jsonpickle.loads(encoded) == [shared, shared]
+
+
+def test_contiguous_decimal_passthrough_ref_ids(
+    simplejson_use_decimal, decimal_passthrough
+):
+    """
+    Skipping a passthrough ref shouldn't shift py/id numbering
+    """
+    shared = decimal.Decimal("2.1")
+    first, second = Thing("a"), Thing("b")
+
+    # the decimals consume no reference IDs, so the Things should still number 1 and 2
+    encoded = jsonpickle.dumps([shared, first, shared, second, first, second])
+    assert encoded.endswith('{"py/id": 1}, {"py/id": 2}]')
+
+    restored = jsonpickle.loads(encoded)
+    assert restored[0] == restored[2] == shared
+    # references still resolve to the same object, not a copy or None
+    assert restored[4] is restored[1]
+    assert restored[5] is restored[3]
+
+
+def test_decimal_passthrough_ref_ids(simplejson_use_decimal, decimal_passthrough):
+    """
+    Ensure that interleaving passthrough and referenced objects matches use_decimal
+    """
+
+    def build():
+        shared = decimal.Decimal("2.1")
+        thing = Thing("a")
+        return [shared, thing, shared, thing, {"t": thing, "d": shared}]
+
+    with_handler = jsonpickle.dumps(build())
+    jsonpickle.handlers.unregister(decimal.Decimal)
+    try:
+        with_flag = jsonpickle.dumps(build(), use_decimal=True)
+    finally:
+        jsonpickle.handlers.register(
+            decimal.Decimal, jsonpickle.handlers.PassthroughHandler, base=True
+        )
+    assert with_handler == with_flag

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -49,7 +49,7 @@ class BackendBase(SkippableTest):
         self._is_installed(backend)
         jsonpickle.set_preferred_backend(backend)
 
-    def tearDown(self):
+    def teardown_method(self):
         # always reset to default backend
         jsonpickle.set_preferred_backend("json")
 
@@ -83,7 +83,7 @@ class BackendBase(SkippableTest):
 
 
 class JsonTestCase(BackendBase):
-    def setUp(self):
+    def setup_method(self):
         self.set_preferred_backend("json")
 
     def test_backend(self):
@@ -98,7 +98,7 @@ class JsonTestCase(BackendBase):
 
 
 class SimpleJsonTestCase(BackendBase):
-    def setUp(self):
+    def setup_method(self):
         self.set_preferred_backend("simplejson")
 
     def test_backend(self):
@@ -160,7 +160,7 @@ def has_module(module):
 
 
 class UJsonTestCase(BackendBase):
-    def setUp(self):
+    def setup_method(self):
         self.set_preferred_backend("ujson")
 
     def test_backend(self):
@@ -174,9 +174,13 @@ class UJsonTestCase(BackendBase):
 
 
 class YamlTestCase(BackendBase):
-    def setUp(self):
+    def setup_method(self):
         jsonpickle.ext.yaml.register()
         self.set_preferred_backend("yaml")
+
+    def teardown_method(self):
+        jsonpickle.remove_backend("yaml")
+        super().teardown_method()
 
     def test_backend(self):
         expected_pickled = (

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -124,17 +124,10 @@ class SimpleJsonTestCase(BackendBase):
         assert obj == clone
 
         # Custom behavior: we want to use simplejson's Decimal support.
+        # Passing Decimal through to simplejson is done by registering PassthroughHandler
         jsonpickle.set_encoder_options("simplejson", use_decimal=True, sort_keys=True)
 
         jsonpickle.set_decoder_options("simplejson", use_decimal=True)
-
-        # use_decimal mode allows Decimal objects to pass-through to simplejson.
-        # The end result is we get a simple '0.5' value as our json string.
-        as_json = jsonpickle.dumps(obj, unpicklable=True, use_decimal=True)
-        assert as_json == "0.5"
-        # But when loading we get back a Decimal.
-        clone = jsonpickle.loads(as_json)
-        assert isinstance(clone, decimal.Decimal)
 
         # side-effect: floats become decimals too!
         obj = 0.5
@@ -228,8 +221,8 @@ def decimal_passthrough():
 
 def test_decimal_passthrough_handler(simplejson_use_decimal, decimal_passthrough):
     """
-    Ensure that PassthroughHandler reproduces use_decimal=True without needing the
-    encode() flag that was removed in jsonpickle v5.
+    Ensure that PassthroughHandler lets Decimal reach simplejson untouched, so it
+    is written as a plain json number rather than a py/reduce payload.
     """
     obj = decimal.Decimal("0.5")
 
@@ -246,27 +239,20 @@ def test_decimal_passthrough_handler(simplejson_use_decimal, decimal_passthrough
 
     shared = decimal.Decimal("2.1")
     values = [
-        decimal.Decimal("2.1"),
-        [decimal.Decimal("2.1"), decimal.Decimal("0.5")],
-        # ensure distinct instances of equal value are not deduplicated by either mode
-        [decimal.Decimal("2.1"), decimal.Decimal("2.1")],
+        (decimal.Decimal("2.1"), "2.1"),
+        ([decimal.Decimal("2.1"), decimal.Decimal("0.5")], "[2.1, 0.5]"),
+        # ensure distinct instances of equal value are not deduplicated
+        ([decimal.Decimal("2.1"), decimal.Decimal("2.1")], "[2.1, 2.1]"),
         # nor should the same instance be turned into a py/id reference
-        [shared, shared],
-        {"a": decimal.Decimal("2.1")},
-        {"a": {"b": [decimal.Decimal("2.1")]}},
-        {decimal.Decimal("2.1"): "a"},
-        DecimalSubclass("2.1"),
+        ([shared, shared], "[2.1, 2.1]"),
+        ({"a": decimal.Decimal("2.1")}, '{"a": 2.1}'),
+        ({"a": {"b": [decimal.Decimal("2.1")]}}, '{"a": {"b": [2.1]}}'),
+        # dict keys are still coerced via repr(), the handler only affects values
+        ({decimal.Decimal("2.1"): "a"}, '{"Decimal(\'2.1\')": "a"}'),
+        (DecimalSubclass("2.1"), "2.1"),
     ]
-    for value in values:
-        with_handler = jsonpickle.dumps(value)
-        jsonpickle.handlers.unregister(decimal.Decimal)
-        try:
-            with_flag = jsonpickle.dumps(value, use_decimal=True)
-        finally:
-            jsonpickle.handlers.register(
-                decimal.Decimal, jsonpickle.handlers.PassthroughHandler, base=True
-            )
-        assert with_handler == with_flag, value
+    for value, expect in values:
+        assert jsonpickle.dumps(value) == expect, value
 
 
 def test_decimal_passthrough_repeated_instance(
@@ -311,24 +297,3 @@ def test_contiguous_decimal_passthrough_ref_ids(
     # references still resolve to the same object, not a copy or None
     assert restored[4] is restored[1]
     assert restored[5] is restored[3]
-
-
-def test_decimal_passthrough_ref_ids(simplejson_use_decimal, decimal_passthrough):
-    """
-    Ensure that interleaving passthrough and referenced objects matches use_decimal
-    """
-
-    def build():
-        shared = decimal.Decimal("2.1")
-        thing = Thing("a")
-        return [shared, thing, shared, thing, {"t": thing, "d": shared}]
-
-    with_handler = jsonpickle.dumps(build())
-    jsonpickle.handlers.unregister(decimal.Decimal)
-    try:
-        with_flag = jsonpickle.dumps(build(), use_decimal=True)
-    finally:
-        jsonpickle.handlers.register(
-            decimal.Decimal, jsonpickle.handlers.PassthroughHandler, base=True
-        )
-    assert with_handler == with_flag

--- a/tests/ecdsa_test.py
+++ b/tests/ecdsa_test.py
@@ -20,7 +20,7 @@ def gmpy_extension():
 
 
 class EcdsaTestCase(SkippableTest):
-    def setUp(self):
+    def setup_method(self):
         try:
             from ecdsa import NIST384p
             from ecdsa.keys import SigningKey

--- a/tests/feedparser_test.py
+++ b/tests/feedparser_test.py
@@ -67,7 +67,7 @@ RSS_DOC = """<?xml version="1.0" encoding="utf-8"?>
 
 
 class FeedParserTestCase(SkippableTest):
-    def setUp(self):
+    def setup_method(self):
         try:
             import feedparser
 
@@ -77,7 +77,7 @@ class FeedParserTestCase(SkippableTest):
             self.should_skip = True
             return
 
-    def test(self):
+    def test_feedparser(self):
         if self.should_skip:
             return self.skip("feedparser module not available, please install")
         pickled = jsonpickle.encode(self.doc)

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -74,10 +74,10 @@ class ContextAwareHandler(jsonpickle.handlers.BaseHandler):
 
 
 class HandlerTestCase:
-    def setUp(self):
+    def setup_method(self):
         jsonpickle.handlers.register(CustomObject, NullHandler)
 
-    def tearDown(self):
+    def teardown_method(self):
         jsonpickle.handlers.unregister(CustomObject)
 
     def roundtrip(self, ob):

--- a/tests/sqlalchemy_test.py
+++ b/tests/sqlalchemy_test.py
@@ -30,7 +30,7 @@ if HAS_SQA:
 
 
 class SQLAlchemyTestCase(SkippableTest):
-    def setUp(self):
+    def setup_method(self):
         """Create a new sqlalchemy engine for the test"""
         if HAS_SQA:
             url = "sqlite:///:memory:"


### PR DESCRIPTION
Thank you for contributing to jsonpickle! This is just a quick template for you to fill out to make sure that jsonpickle can stay insulated from any legal uncertainty regarding copyrightability of code made by generative AI, and to make sure that we keep the code base easily maintainable. 

In order for us to merge your PR, please confirm that all of these boxes are true when applied to this PR and check them if so. If any box is not applicable to your PR (e.g. if you made a documentation-only change), you should just check it instead of deleting it or leaving it un-checked.

- [x] If this PR changes any non-documentation portion of the codebase, I have updated the ``CHANGES.rst`` file for this change.
   - [x] In the CHANGES.rst update, I added a link to the PR number that this will be (e.g. ``(+611)``) and (if applicable) added a link to the issue that this fixes (e.g. ``(#608)``).
- [x] If this PR fixes a bug or adds a feature, I have added appropriate tests.
- [x] I have run the tests with ``pytest`` and run formatting with ``ruff format``.
- [x] If generative AI of any kind was used in creating this PR, I have followed the these guidelines:
   - [x] I ensured that this PR is not entirely written by any generative AI model.
   - [x] I ensured that any portions of the code written by any generative AI model are free from copyrighted code.
   - [x] I ensured that I included a Co-authored-by or Assisted-by tag in the footer of every commit where AI is used containing the name of all generative AI models used for that commit.
   - x] I ensured that all code in this PR submitted verbatim from generative AI output is limited to creating/fixing tests/documentation and/or fixing bugs in extensions, and does not impact the core code.
   - [x] **I understand that if I used AI and the above checkmarks are not all true when I submit this PR, my PR will be closed.**
- [x] **I understand that if this checklist is deleted from the PR body, my PR will be closed.**
---

This PR finally gets around to removing the ``use_decimal`` encoder option as discussed in #591. It uses the passthrough  idea (thanks @davvid!) and adds a replacement that also works for any types as long as the backend supports it. I believe that currently the only type that this applies to is Decimal, but I was considering adding an orjson backend for v5 which might end up needing a passthrough for more types. It also fixes a bunch of tests that weren't running or even being collected because they were inside classes that pytest wasn't catching. I considered splitting that fix into a different PR but decided against it because some of those tests that it didn't initially catch also apply to the passthrough handler so I wanted to make sure the passthrough replacement got full coverage.

I'll be trying to get to the other removals planned for v5 later today!